### PR TITLE
feat: implement ReviewController

### DIFF
--- a/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
@@ -1,0 +1,76 @@
+package com.example.lxp.review.adapter.in.web;
+
+import com.example.lxp.review.adapter.in.web.dto.CreateReviewRequest;
+import com.example.lxp.review.adapter.in.web.dto.UpdateReviewRequest;
+import com.example.lxp.review.application.port.in.ReviewCommandUseCase;
+import com.example.lxp.review.application.port.in.dto.CreateReviewCommand;
+import com.example.lxp.review.application.port.in.dto.DeleteReviewCommand;
+import com.example.lxp.review.application.port.in.dto.UpdateReviewCommand;
+import com.example.lxp.review.domain.model.Rating;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/courses/{courseId}/reviews")
+public class ReviewController {
+
+    // TODO: replace with authenticated user id once credential is integrated
+    private static final Long USER_ID_STUB = 1L;
+
+    private final ReviewCommandUseCase reviewCommandUseCase;
+
+    public ReviewController(ReviewCommandUseCase reviewCommandUseCase) {
+        this.reviewCommandUseCase = reviewCommandUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createReview(
+            @PathVariable Long courseId,
+            @RequestBody @Valid CreateReviewRequest body
+    ) {
+        CreateReviewCommand command = new CreateReviewCommand(
+                USER_ID_STUB,
+                courseId,
+                body.title(),
+                body.comment(),
+                Rating.of(body.stars())
+        );
+        reviewCommandUseCase.createReview(command);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<Void> updateReview(
+            @PathVariable Long courseId,
+            @PathVariable Long reviewId,
+            @RequestBody @Valid UpdateReviewRequest body
+    ) {
+        UpdateReviewCommand command = new UpdateReviewCommand(
+                USER_ID_STUB,
+                courseId,
+                reviewId,
+                body.title(),
+                body.comment(),
+                Rating.of(body.stars())
+        );
+        reviewCommandUseCase.updateReview(command);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @PathVariable Long courseId,
+            @PathVariable Long reviewId
+    ) {
+        DeleteReviewCommand command = new DeleteReviewCommand(
+                USER_ID_STUB,
+                courseId,
+                reviewId
+        );
+        reviewCommandUseCase.deleteReview(command);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/example/lxp/review/adapter/in/web/dto/CreateReviewRequest.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/dto/CreateReviewRequest.java
@@ -1,0 +1,11 @@
+package com.example.lxp.review.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateReviewRequest(
+        @NotBlank String title,
+        @NotBlank String comment,
+        @NotNull Integer stars
+) {
+}

--- a/src/main/java/com/example/lxp/review/adapter/in/web/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/dto/UpdateReviewRequest.java
@@ -1,0 +1,11 @@
+package com.example.lxp.review.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateReviewRequest(
+        @NotBlank String title,
+        @NotBlank String comment,
+        @NotNull Integer stars
+) {
+}


### PR DESCRIPTION
- Add ReviewController with create/update/delete endpoints mapping request DTOs + path vars to review command use case.
- Introduce request DTOs for review writes (CreateReviewRequest, UpdateReviewRequest) receiving stars as Integer before converting to Rating.

---

- 코스 리뷰 생성/수정/삭제 엔드포인트를 제공하는 ReviewController를 추가하고, 요청 DTO와 경로 변수를 조합해 커맨드로 변환합니다.
- 리뷰 작성/수정용 요청 DTO(CreateReviewRequest, UpdateReviewRequest)를 추가하여 stars를 Integer로 받아 도메인 Rating으로 변환합니다.