### PR TITLE
feat: implement QnA domain

### DIFF
--- a/src/main/java/com/example/lxp/exception/ErrorCode.java
+++ b/src/main/java/com/example/lxp/exception/ErrorCode.java
@@ -18,7 +18,17 @@ public enum ErrorCode {
     USER_NOT_ENROLLED_IN_COURSE(HttpStatus.FORBIDDEN, "You can only write reviews for courses you are enrolled in."),
 
     // 404 Not Found: Resource Not Found Errors
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review not found");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "Review not found"),
+
+    // QnA Domain Error Codes
+    INVALID_QUESTION_TITLE(HttpStatus.BAD_REQUEST, "Invalid question title"),
+    INVALID_QUESTION_CONTENT(HttpStatus.BAD_REQUEST, "Invalid question content"),
+    FORBIDDEN_QUESTION_MODIFICATION(HttpStatus.FORBIDDEN, "Only the author can modify the question"),
+    FORBIDDEN_QUESTION_REPLY(HttpStatus.FORBIDDEN, "Only the root author or instructor can reply to this question"),
+    INVALID_QUESTION_OPERATION(HttpStatus.BAD_REQUEST, "Invalid operation for the current question type or status."),
+    NOT_A_ROOT_QUESTION(HttpStatus.BAD_REQUEST, "This operation can only be performed on a root question."),
+    ID_NOT_GENERATED(HttpStatus.INTERNAL_SERVER_ERROR, "Cannot perform operation before ID is generated."),
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Question not found");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
@@ -1,0 +1,73 @@
+package com.example.lxp.qna.adapter.in.web;
+
+import com.example.lxp.qna.adapter.in.web.dto.CreateQuestionRequest;
+import com.example.lxp.qna.adapter.in.web.dto.UpdateQuestionRequest;
+import com.example.lxp.qna.application.port.in.QuestionCommandUseCase;
+import com.example.lxp.qna.application.port.in.dto.CreateQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.DeleteQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.UpdateQuestionCommand;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/courses/{courseId}/lessons/{lessonId}/qna")
+public class QnaController {
+
+    // TODO: replace with authenticated user id once credential is integrated
+    private static final Long USER_ID_STUB = 1L;
+
+    private final QuestionCommandUseCase questionCommandUseCase;
+
+    public QnaController(QuestionCommandUseCase questionCommandUseCase) {
+        this.questionCommandUseCase = questionCommandUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createQuestion(
+            @PathVariable Long courseId,
+            @PathVariable Long lessonId,
+            @RequestBody @Valid CreateQuestionRequest body
+    ) {
+        CreateQuestionCommand command = new CreateQuestionCommand(
+                body.rootId(),
+                body.threadId(),
+                courseId,
+                lessonId,
+                body.title(),
+                body.content(),
+                USER_ID_STUB
+        );
+        questionCommandUseCase.createQuestion(command);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping("/{questionId}")
+    public ResponseEntity<Void> updateQuestion(
+            @PathVariable Long questionId,
+            @RequestBody @Valid UpdateQuestionRequest body
+    ) {
+        UpdateQuestionCommand command = new UpdateQuestionCommand(
+                questionId,
+                body.title(),
+                body.content(),
+                USER_ID_STUB
+        );
+        questionCommandUseCase.updateQuestion(command);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<Void> deleteQuestion(
+            @PathVariable Long questionId
+    ) {
+        DeleteQuestionCommand command = new DeleteQuestionCommand(
+                questionId,
+                USER_ID_STUB
+        );
+        questionCommandUseCase.deleteQuestion(command);
+        return ResponseEntity.noContent().build();
+    }
+    
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
@@ -15,8 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/courses/{courseId}/lessons/{lessonId}/qna")
 public class QnaController {
 
-    // TODO: replace with authenticated user id once credential is integrated
-    private static final Long USER_ID_STUB = 1L;
+    private static final String HEADER_USER_ID = "X-User-Id";
 
     private final QuestionCommandUseCase questionCommandUseCase;
 
@@ -28,7 +27,8 @@ public class QnaController {
     public ResponseEntity<Void> createQuestion(
             @PathVariable Long courseId,
             @PathVariable Long lessonId,
-            @RequestBody @Valid CreateQuestionRequest body
+            @RequestBody @Valid CreateQuestionRequest body,
+            @RequestHeader(HEADER_USER_ID) Long userId
     ) {
         CreateQuestionCommand command = new CreateQuestionCommand(
                 body.rootId(),
@@ -37,7 +37,7 @@ public class QnaController {
                 lessonId,
                 body.title(),
                 body.content(),
-                USER_ID_STUB
+                userId
         );
         questionCommandUseCase.createQuestion(command);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -46,13 +46,14 @@ public class QnaController {
     @PutMapping("/{questionId}")
     public ResponseEntity<Void> updateQuestion(
             @PathVariable Long questionId,
-            @RequestBody @Valid UpdateQuestionRequest body
+            @RequestBody @Valid UpdateQuestionRequest body,
+            @RequestHeader(HEADER_USER_ID) Long userId
     ) {
         UpdateQuestionCommand command = new UpdateQuestionCommand(
                 questionId,
                 body.title(),
                 body.content(),
-                USER_ID_STUB
+                userId
         );
         questionCommandUseCase.updateQuestion(command);
         return ResponseEntity.ok().build();
@@ -60,14 +61,15 @@ public class QnaController {
 
     @DeleteMapping("/{questionId}")
     public ResponseEntity<Void> deleteQuestion(
-            @PathVariable Long questionId
+            @PathVariable Long questionId,
+            @RequestHeader(HEADER_USER_ID) Long userId
     ) {
         DeleteQuestionCommand command = new DeleteQuestionCommand(
                 questionId,
-                USER_ID_STUB
+                userId
         );
         questionCommandUseCase.deleteQuestion(command);
         return ResponseEntity.noContent().build();
     }
-    
+
 }

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
@@ -43,10 +43,10 @@ public class QnaController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PutMapping("/{questionId}")
+    @PatchMapping("/{questionId}")
     public ResponseEntity<Void> updateQuestion(
             @PathVariable Long questionId,
-            @RequestBody @Valid UpdateQuestionRequest body,
+            @RequestBody UpdateQuestionRequest body,
             @RequestHeader(HEADER_USER_ID) Long userId
     ) {
         UpdateQuestionCommand command = new UpdateQuestionCommand(

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/dto/CreateQuestionRequest.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/dto/CreateQuestionRequest.java
@@ -1,0 +1,12 @@
+package com.example.lxp.qna.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateQuestionRequest(
+        Long rootId,
+        String threadId,
+        String title,
+        @NotBlank(message = "Content is required")
+        String content
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UpdateQuestionRequest.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UpdateQuestionRequest.java
@@ -1,0 +1,7 @@
+package com.example.lxp.qna.adapter.in.web.dto;
+
+public record UpdateQuestionRequest(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaPersistenceAdapter.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package com.example.lxp.qna.adapter.out.persistence;
+
+import com.example.lxp.qna.application.port.out.QnaPersistencePort;
+import com.example.lxp.qna.domain.model.Question;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class QnaPersistenceAdapter implements QnaPersistencePort {
+
+    private final QnaRepository qnaRepository;
+
+    public QnaPersistenceAdapter(QnaRepository qnaRepository) {
+        this.qnaRepository = qnaRepository;
+    }
+
+    @Override
+    public Question save(Question question) {
+        return qnaRepository.save(question);
+    }
+
+    @Override
+    public Optional<Question> findById(Long questionId) {
+        return qnaRepository.findById(questionId);
+    }
+
+    @Override
+    public void delete(Question question) {
+        qnaRepository.delete(question);
+    }
+
+    @Override
+    public void deleteByThreadId(String threadId) {
+        qnaRepository.deleteByThreadId(threadId);
+    }
+}

--- a/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaRepository.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaRepository.java
@@ -1,0 +1,9 @@
+package com.example.lxp.qna.adapter.out.persistence;
+
+import com.example.lxp.qna.domain.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnaRepository extends JpaRepository<Question, Long> {
+
+    void deleteByThreadId(String threadId);
+}

--- a/src/main/java/com/example/lxp/qna/application/port/in/QuestionCommandUseCase.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/QuestionCommandUseCase.java
@@ -1,0 +1,17 @@
+package com.example.lxp.qna.application.port.in;
+
+import com.example.lxp.qna.application.port.in.dto.CreateQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.DeleteQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.UpdateQuestionCommand;
+import com.example.lxp.qna.domain.model.Question;
+
+public interface QuestionCommandUseCase {
+
+    Question createQuestion(CreateQuestionCommand command);
+
+    Question updateQuestion(UpdateQuestionCommand command);
+
+    void deleteQuestion(DeleteQuestionCommand command);
+
+}
+

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/CreateQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/CreateQuestionCommand.java
@@ -1,0 +1,12 @@
+package com.example.lxp.qna.application.port.in.dto;
+
+public record CreateQuestionCommand(
+        Long rootId,
+        String threadId,
+        Long courseId,
+        Long lessonId,
+        String title,
+        String comment,
+        Long authorId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/DeleteQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/DeleteQuestionCommand.java
@@ -1,0 +1,7 @@
+package com.example.lxp.qna.application.port.in.dto;
+
+public record DeleteQuestionCommand(
+        Long questionId,
+        Long authorId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/UpdateQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/UpdateQuestionCommand.java
@@ -1,0 +1,9 @@
+package com.example.lxp.qna.application.port.in.dto;
+
+public record UpdateQuestionCommand(
+        Long questionId,
+        String title,
+        String comment,
+        Long authorId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/application/port/out/QnaPersistencePort.java
+++ b/src/main/java/com/example/lxp/qna/application/port/out/QnaPersistencePort.java
@@ -1,0 +1,17 @@
+package com.example.lxp.qna.application.port.out;
+
+import com.example.lxp.qna.domain.model.Question;
+
+import java.util.Optional;
+
+public interface QnaPersistencePort {
+
+    Question save(Question question);
+
+    Optional<Question> findById(Long questionId);
+
+    void delete(Question question);
+
+    void deleteByThreadId(String threadId);
+    
+}

--- a/src/main/java/com/example/lxp/qna/application/port/out/VerifyInstructorPort.java
+++ b/src/main/java/com/example/lxp/qna/application/port/out/VerifyInstructorPort.java
@@ -1,0 +1,7 @@
+package com.example.lxp.qna.application.port.out;
+
+public interface VerifyInstructorPort {
+
+    boolean isInstructor(Long instructorId);
+    
+}

--- a/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
+++ b/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
@@ -1,0 +1,125 @@
+package com.example.lxp.qna.application.service;
+
+import com.example.lxp.common.port.out.PublishEventPort;
+import com.example.lxp.exception.BusinessException;
+import com.example.lxp.exception.ErrorCode;
+import com.example.lxp.qna.application.port.in.QuestionCommandUseCase;
+import com.example.lxp.qna.application.port.in.dto.CreateQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.DeleteQuestionCommand;
+import com.example.lxp.qna.application.port.in.dto.UpdateQuestionCommand;
+import com.example.lxp.qna.application.port.out.QnaPersistencePort;
+import com.example.lxp.qna.application.port.out.VerifyInstructorPort;
+import com.example.lxp.qna.domain.event.QuestionCreatedEvent;
+import com.example.lxp.qna.domain.model.Question;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@Transactional
+public class QnaCommandService implements QuestionCommandUseCase {
+
+    private final QnaPersistencePort qnaPersistencePort;
+    private final PublishEventPort publishEventPort;
+    private final VerifyInstructorPort verifyInstructorPort;
+
+    public QnaCommandService(
+            QnaPersistencePort qnaPersistencePort,
+            PublishEventPort publishEventPort,
+            VerifyInstructorPort verifyInstructorPort
+    ) {
+        this.qnaPersistencePort = qnaPersistencePort;
+        this.publishEventPort = publishEventPort;
+        this.verifyInstructorPort = verifyInstructorPort;
+    }
+
+    @Override
+    public Question createQuestion(CreateQuestionCommand command) {
+        if (command.rootId() == null) {
+            if (command.threadId() != null && !command.threadId().isBlank()) {
+                throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+            }
+
+            Question question = Question.createRoot(
+                    command.courseId(),
+                    command.lessonId(),
+                    command.authorId(),
+                    command.title(),
+                    command.comment()
+            );
+
+            Question savedQuestion = qnaPersistencePort.save(question);
+            publishEventPort.publish(QuestionCreatedEvent.from(savedQuestion));
+            return savedQuestion;
+        }
+
+        Question parentQuestion = qnaPersistencePort.findById(command.rootId())
+                .orElseThrow(() -> BusinessException.builder(ErrorCode.QUESTION_NOT_FOUND).build());
+
+        if (!Objects.equals(parentQuestion.getCourseId(), command.courseId())
+                || !Objects.equals(parentQuestion.getLessonId(), command.lessonId())) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+
+        if (command.threadId() != null && !Objects.equals(parentQuestion.getThreadId(), command.threadId())) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+
+        if (parentQuestion.getRootId() != null) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+
+        if (!canReply(parentQuestion, command.authorId())) {
+            throw BusinessException.builder(ErrorCode.FORBIDDEN_QUESTION_REPLY).build();
+        }
+
+        Question reply = Question.createReply(
+                command.rootId(),
+                parentQuestion.getThreadId(),
+                command.courseId(),
+                command.lessonId(),
+                command.authorId(),
+                command.comment()
+        );
+
+        Question savedReply = qnaPersistencePort.save(reply);
+        publishEventPort.publish(QuestionCreatedEvent.from(savedReply));
+
+        return savedReply;
+    }
+
+    @Override
+    public Question updateQuestion(UpdateQuestionCommand command) {
+        Question question = qnaPersistencePort.findById(command.questionId())
+                .orElseThrow(() -> BusinessException.builder(ErrorCode.QUESTION_NOT_FOUND).build());
+
+        question.update(
+                command.authorId(),
+                command.title(),
+                command.comment()
+        );
+
+        return qnaPersistencePort.save(question);
+    }
+
+    @Override
+    public void deleteQuestion(DeleteQuestionCommand command) {
+        Question question = qnaPersistencePort.findById(command.questionId())
+                .orElseThrow(() -> BusinessException.builder(ErrorCode.QUESTION_NOT_FOUND).build());
+
+        if (question.getRootId() != null) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+
+        question.delete(command.authorId());
+        qnaPersistencePort.deleteByThreadId(question.getThreadId());
+    }
+
+    private boolean canReply(Question rootQuestion, Long replierId) {
+        boolean isRootAuthor = Objects.equals(rootQuestion.getAuthorId(), replierId);
+        boolean isInstructor = verifyInstructorPort.isInstructor(replierId);
+        return isRootAuthor || isInstructor;
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
+++ b/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
@@ -108,12 +108,12 @@ public class QnaCommandService implements QuestionCommandUseCase {
         Question question = qnaPersistencePort.findById(command.questionId())
                 .orElseThrow(() -> BusinessException.builder(ErrorCode.QUESTION_NOT_FOUND).build());
 
-        if (question.getRootId() != null) {
-            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
-        }
-
         question.delete(command.authorId());
-        qnaPersistencePort.deleteByThreadId(question.getThreadId());
+        if (question.getRootId() == null) {
+            qnaPersistencePort.deleteByThreadId(question.getThreadId());
+        } else {
+            qnaPersistencePort.delete(question);
+        }
     }
 
     private boolean canReply(Question rootQuestion, Long replierId) {

--- a/src/main/java/com/example/lxp/qna/domain/event/QuestionCreatedEvent.java
+++ b/src/main/java/com/example/lxp/qna/domain/event/QuestionCreatedEvent.java
@@ -1,0 +1,50 @@
+package com.example.lxp.qna.domain.event;
+
+import com.example.lxp.qna.domain.model.Question;
+
+public class QuestionCreatedEvent {
+
+    private final Long questionId;
+    private final String threadId;
+    private final Long courseId;
+    private final Long lessonId;
+    private final Long authorId;
+
+    private QuestionCreatedEvent(Long questionId, String threadId, Long courseId, Long lessonId, Long authorId) {
+        this.questionId = questionId;
+        this.threadId = threadId;
+        this.courseId = courseId;
+        this.lessonId = lessonId;
+        this.authorId = authorId;
+    }
+
+    public static QuestionCreatedEvent from(Question question) {
+        return new QuestionCreatedEvent(
+                question.getId(),
+                question.getThreadId(),
+                question.getCourseId(),
+                question.getLessonId(),
+                question.getAuthorId()
+        );
+    }
+
+    public Long getQuestionId() {
+        return questionId;
+    }
+
+    public String getThreadId() {
+        return threadId;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public Long getLessonId() {
+        return lessonId;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+}

--- a/src/main/java/com/example/lxp/qna/domain/model/Question.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/Question.java
@@ -1,0 +1,196 @@
+package com.example.lxp.qna.domain.model;
+
+import com.example.lxp.exception.BusinessException;
+import com.example.lxp.exception.ErrorCode;
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(
+        indexes = {
+                @Index(name = "idx_question_thread_id", columnList = "thread_id"),
+                @Index(name = "idx_question_parent_id", columnList = "parent_id")
+        }
+)
+public class Question {
+
+    // Relation Fields ----------
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "root_id", nullable = true)
+    private Long rootId;
+
+    @Column(name = "thread_id", nullable = false, length = 36)
+    private String threadId;
+
+    @Column(nullable = false)
+    private Long courseId;
+
+    @Column(nullable = false)
+    private Long lessonId;
+
+    @Column(nullable = false)
+    private Long authorId;
+
+    // Content Fields ----------
+
+    @Column(nullable = true)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    // Metadata Fields ----------
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private QuestionStatus status;
+
+    // Constructors ----------
+
+    protected Question() {}
+
+    private Question(Long rootId, String threadId, Long courseId, Long lessonId, Long authorId, String title, String content) {
+        validate(title, content, rootId, threadId);
+        this.rootId = rootId;
+        this.threadId = threadId;
+        this.courseId = courseId;
+        this.lessonId = lessonId;
+        this.authorId = authorId;
+        this.title = title;
+        this.content = content;
+        this.status = QuestionStatus.OPENED;
+    }
+
+    // Factory Methods ----------
+
+    public static Question createRoot(Long courseId, Long lessonId, Long authorId, String title, String content) {
+        String threadId = UUID.randomUUID().toString();
+        return new Question(null, threadId, courseId, lessonId, authorId, title, content);
+    }
+
+    public static Question createReply(Long rootId, String threadId, Long courseId, Long lessonId, Long authorId, String content) {
+        return new Question(rootId, threadId, courseId, lessonId, authorId, null, content);
+    }
+
+    // Business Logics ----------
+
+    public void update(Long userId, String title, String content) {
+        if (!isAuthor(userId)) {
+            throw BusinessException.builder(ErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
+        }
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (content != null && !content.isBlank()) {
+            this.content = content;
+        }
+    }
+
+    public void delete(Long userId) {
+        if (!isAuthor(userId)) {
+            throw BusinessException.builder(ErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
+        }
+        this.status = QuestionStatus.DELETED;
+    }
+
+    // MVP-002: 추후 업데이트로 질문의 상태 변화에 대한 코드 적용 예정
+    public void resolve(Long userId) {
+        if (!isAuthor(userId)) {
+            throw BusinessException.builder(ErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
+        }
+        if (this.rootId != null) { // This question is a reply
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+        this.status = QuestionStatus.RESOLVED;
+    }
+
+    // Helper Methods ----------
+
+    private boolean isAuthor(Long userId) {
+        return Objects.equals(this.authorId, userId);
+    }
+
+    private void validate(String title, String content, Long rootId, String threadId) { // Renamed param to parentId
+        if (content == null || content.isBlank()) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_CONTENT).build();
+        }
+        if (rootId == null && (title == null || title.isBlank())) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_TITLE).build();
+        }
+        if (threadId == null || threadId.isBlank()) {
+            throw BusinessException.builder(ErrorCode.INVALID_QUESTION_OPERATION).build();
+        }
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    // Getters ----------
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public Long getLessonId() {
+        return lessonId;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public Long getRootId() {
+        return rootId;
+    }
+
+    public String getThreadId() {
+        return threadId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public QuestionStatus getStatus() {
+        return status;
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/domain/model/Question.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/Question.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Table(
         indexes = {
                 @Index(name = "idx_question_thread_id", columnList = "thread_id"),
-                @Index(name = "idx_question_parent_id", columnList = "parent_id")
+                @Index(name = "idx_question_root_id", columnList = "root_id")
         }
 )
 public class Question {
@@ -100,6 +100,7 @@ public class Question {
         }
     }
 
+    // Soft Delete 및 질문의 상태 변화 구현시 사용 예정
     public void delete(Long userId) {
         if (!isAuthor(userId)) {
             throw BusinessException.builder(ErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
@@ -124,7 +125,7 @@ public class Question {
         return Objects.equals(this.authorId, userId);
     }
 
-    private void validate(String title, String content, Long rootId, String threadId) { // Renamed param to parentId
+    private void validate(String title, String content, Long rootId, String threadId) {
         if (content == null || content.isBlank()) {
             throw BusinessException.builder(ErrorCode.INVALID_QUESTION_CONTENT).build();
         }

--- a/src/main/java/com/example/lxp/qna/domain/model/QuestionStatus.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/QuestionStatus.java
@@ -1,0 +1,8 @@
+package com.example.lxp.qna.domain.model;
+
+public enum QuestionStatus {
+    OPENED,       // Question is active and awaiting answers
+    RESOLVED,   // Question has been satisfactorily answered
+    CLOSED,     // Question thread is closed (e.g., by instructor or admin)
+    DELETED     // Question has been deleted
+}


### PR DESCRIPTION
* 도메인 계층 (`qna.domain`):
  * 루트 질문과 답변을 모두 나타내는 핵심 엔티티인 Question을 도입했습니다.
  * 질문과 답변을 단일 스레드로 그룹화하기 위해 threadId를 구현했습니다.
  * Q&A 관련 비즈니스 예외를 처리하기 위해 다양한 ErrorCode enum을 추가했습니다.

* 애플리케이션 계층 (`qna.application`):
  * Q&A 기능의 기본 작업(생성, 업데이트, 삭제)을 정의하기 위해 QuestionCommandUseCase를 만들었습니다.
  * 핵심 비즈니스 로직을 포함하는 QnaCommandService를 구현했습니다.
    * rootId의 존재 여부에 따라 루트 질문과 답변 생성을 구별합니다.
    * 새 루트 질문에 대한 threadId를 생성합니다.
    * 답변에 threadId를 전파합니다.
    * 답변 생성에 대한 사용자 권한(작성자 또는 강사)을 확인합니다.
  * 서비스 계층으로의 깨끗한 데이터 전송을 위해 DTO(CreateQuestionCommand 등)를 추가했습니다.

* 어댑터 계층 (`qna.adapter`):
  * 웹 어댑터 (`in.web`):
    * `POST /api/courses/{courseId}/lessons/{lessonId}/qna`, `PUT /{questionId}, DELETE /{questionId}` 엔드포인트가 있는 QnaController를 추가했습니다.
    * API 입력을 처리하기 위해 요청 DTO(CreateQuestionRequest, UpdateQuestionRequest)를 만들었습니다.
  * 영속성 어댑터 (`out.persistence`):
    * Spring Data JPA를 사용하여 Question 엔티티의 데이터베이스 작업을 처리하기 위해 QnaPersistenceAdapter 및 QnaRepository를 구현했습니다.