### PR TITLE
refactor: review domain now use User VO to handle user id and role

### DIFF
--- a/src/main/java/com/example/lxp/common/model/dto/Role.java
+++ b/src/main/java/com/example/lxp/common/model/dto/Role.java
@@ -1,0 +1,7 @@
+package com.example.lxp.common.model.dto;
+
+public enum Role {
+    ADMIN,
+    INSTRUCTOR,
+    STUDENT
+}

--- a/src/main/java/com/example/lxp/common/model/dto/User.java
+++ b/src/main/java/com/example/lxp/common/model/dto/User.java
@@ -1,0 +1,7 @@
+package com.example.lxp.common.model.dto;
+
+public record User(
+        Long id,
+        Role role
+) {
+}

--- a/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
@@ -1,5 +1,7 @@
 package com.example.lxp.review.adapter.in.web;
 
+import com.example.lxp.common.model.dto.Role;
+import com.example.lxp.common.model.dto.User;
 import com.example.lxp.review.adapter.in.web.dto.CreateReviewRequest;
 import com.example.lxp.review.adapter.in.web.dto.UpdateReviewRequest;
 import com.example.lxp.review.application.port.in.ReviewCommandUseCase;
@@ -8,15 +10,27 @@ import com.example.lxp.review.application.port.in.dto.DeleteReviewCommand;
 import com.example.lxp.review.application.port.in.dto.UpdateReviewCommand;
 import com.example.lxp.review.domain.model.Rating;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/courses/{courseId}/reviews")
 public class ReviewController {
 
     private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-USER-Role";
 
     private final ReviewCommandUseCase reviewCommandUseCase;
 
@@ -26,16 +40,17 @@ public class ReviewController {
 
     @PostMapping
     public ResponseEntity<Void> createReview(
-            @RequestHeader(HEADER_USER_ID) Long userId,
-            @PathVariable Long courseId,
-            @RequestBody @Valid CreateReviewRequest body
+            @PathVariable @Positive Long courseId,
+            @RequestHeader(HEADER_USER_ID) @Positive Long userId,
+            @RequestHeader(HEADER_USER_ROLE) @NotNull String userRole,
+            @RequestBody @Valid CreateReviewRequest request
     ) {
         CreateReviewCommand command = new CreateReviewCommand(
-                userId,
                 courseId,
-                body.title(),
-                body.comment(),
-                Rating.of(body.stars())
+                new User(userId, Role.valueOf(userRole)),
+                request.title(),
+                request.comment(),
+                Rating.of(request.stars())
         );
         reviewCommandUseCase.createReview(command);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -43,18 +58,19 @@ public class ReviewController {
 
     @PutMapping("/{reviewId}")
     public ResponseEntity<Void> updateReview(
-            @RequestHeader(HEADER_USER_ID) Long userId,
             @PathVariable Long courseId,
             @PathVariable Long reviewId,
-            @RequestBody @Valid UpdateReviewRequest body
+            @RequestHeader(HEADER_USER_ID) Long userId,
+            @RequestHeader(HEADER_USER_ROLE) String userRole,
+            @RequestBody @Valid UpdateReviewRequest request
     ) {
         UpdateReviewCommand command = new UpdateReviewCommand(
-                userId,
                 courseId,
                 reviewId,
-                body.title(),
-                body.comment(),
-                Rating.of(body.stars())
+                new User(userId, Role.valueOf(userRole)),
+                request.title(),
+                request.comment(),
+                Rating.of(request.stars())
         );
         reviewCommandUseCase.updateReview(command);
         return ResponseEntity.ok().build();
@@ -62,14 +78,15 @@ public class ReviewController {
 
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<Void> deleteReview(
-            @RequestHeader(HEADER_USER_ID) Long userId,
             @PathVariable Long courseId,
-            @PathVariable Long reviewId
+            @PathVariable Long reviewId,
+            @RequestHeader(HEADER_USER_ID) Long userId,
+            @RequestHeader(HEADER_USER_ROLE) String userRole
     ) {
         DeleteReviewCommand command = new DeleteReviewCommand(
-                userId,
                 courseId,
-                reviewId
+                reviewId,
+                new User(userId, Role.valueOf(userRole))
         );
         reviewCommandUseCase.deleteReview(command);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/lxp/review/adapter/in/web/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/dto/UpdateReviewRequest.java
@@ -1,11 +1,8 @@
 package com.example.lxp.review.adapter.in.web.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-
 public record UpdateReviewRequest(
-        @NotBlank String title,
-        @NotBlank String comment,
-        @NotNull Integer stars
+        String title,
+        String comment,
+        Integer stars
 ) {
 }

--- a/src/main/java/com/example/lxp/review/adapter/out/external/EnrollmentClientAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/EnrollmentClientAdapter.java
@@ -1,0 +1,14 @@
+package com.example.lxp.review.adapter.out.external;
+
+import com.example.lxp.review.application.port.out.CheckEnrollmentPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnrollmentClientAdapter implements CheckEnrollmentPort {
+
+    @Override
+    public boolean isEnrolled(Long userId, Long courseId) {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/persistence/EventPublisherAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/persistence/EventPublisherAdapter.java
@@ -1,0 +1,14 @@
+package com.example.lxp.review.adapter.out.persistence;
+
+import com.example.lxp.common.port.out.external.PublishEventPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventPublisherAdapter implements PublishEventPort {
+
+    @Override
+    public void publish(Object event) {
+        // TODO
+    }
+
+}

--- a/src/main/java/com/example/lxp/review/application/port/in/dto/CreateReviewCommand.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/dto/CreateReviewCommand.java
@@ -1,12 +1,13 @@
 package com.example.lxp.review.application.port.in.dto;
 
+import com.example.lxp.common.model.dto.User;
 import com.example.lxp.review.domain.model.Rating;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateReviewCommand(
-        @NotNull Long authorId,
         @NotNull Long courseId,
+        @NotNull User user,
         @NotBlank String title,
         @NotBlank String comment,
         @NotNull Rating rating

--- a/src/main/java/com/example/lxp/review/application/port/in/dto/DeleteReviewCommand.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/dto/DeleteReviewCommand.java
@@ -1,10 +1,11 @@
 package com.example.lxp.review.application.port.in.dto;
 
+import com.example.lxp.common.model.dto.User;
 import jakarta.validation.constraints.NotNull;
 
 public record DeleteReviewCommand(
-        @NotNull Long authorId,
         @NotNull Long courseId,
-        @NotNull Long reviewId
+        @NotNull Long reviewId,
+        @NotNull User user
 ) {
 }

--- a/src/main/java/com/example/lxp/review/application/port/in/dto/UpdateReviewCommand.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/dto/UpdateReviewCommand.java
@@ -1,13 +1,14 @@
 package com.example.lxp.review.application.port.in.dto;
 
+import com.example.lxp.common.model.dto.User;
 import com.example.lxp.review.domain.model.Rating;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateReviewCommand(
-        @NotNull Long authorId,
         @NotNull Long courseId,
         @NotNull Long reviewId,
+        @NotNull User user,
         @NotBlank String title,
         @NotBlank String comment,
         @NotNull Rating rating

--- a/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
@@ -1,6 +1,6 @@
 package com.example.lxp.review.application.service;
 
-import com.example.lxp.common.port.out.PublishEventPort;
+import com.example.lxp.common.port.out.external.PublishEventPort;
 import com.example.lxp.exception.BusinessException;
 import com.example.lxp.review.application.port.in.ReviewCommandUseCase;
 import com.example.lxp.review.application.port.in.dto.CreateReviewCommand;
@@ -40,14 +40,14 @@ public class ReviewCommandService implements ReviewCommandUseCase {
     @Override
     public void createReview(CreateReviewCommand command) {
         // EXTERNAL: OUTGOING
-        if (!checkEnrollmentPort.isEnrolled(command.authorId(), command.courseId())) {
+        if (!checkEnrollmentPort.isEnrolled(command.user().id(), command.courseId())) {
             throw BusinessException.builder(ReviewErrorCode.USER_NOT_ENROLLED_IN_COURSE).build();
         }
-        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.authorId(), command.courseId()).isPresent()) {
+        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.user().id(), command.courseId()).isPresent()) {
             throw BusinessException.builder(ReviewErrorCode.REVIEW_ALREADY_EXISTS).build();
         }
         Review review = Review.create(
-                command.authorId(),
+                command.user().id(),
                 command.courseId(),
                 command.title(),
                 command.comment(),
@@ -61,10 +61,10 @@ public class ReviewCommandService implements ReviewCommandUseCase {
 
     @Override
     public void updateReview(UpdateReviewCommand command) {
-        Review review = findAndValidateReview(command.reviewId(), command.authorId(), command.courseId());
+        Review review = findAndValidateReview(command.reviewId(), command.user().id(), command.courseId());
 
         review.update(
-                command.authorId(),
+                command.user().id(),
                 command.title(),
                 command.comment(),
                 command.rating()
@@ -77,7 +77,7 @@ public class ReviewCommandService implements ReviewCommandUseCase {
 
     @Override
     public void deleteReview(DeleteReviewCommand command) {
-        Review review = findAndValidateReview(command.reviewId(), command.authorId(), command.courseId());
+        Review review = findAndValidateReview(command.reviewId(), command.user().id(), command.courseId());
 
         reviewPersistencePort.delete(review);
 


### PR DESCRIPTION
* Controller / Service 사이에서 Command DTO에 필드 값으로 user id를 전달하는 대신, user role과 함께 VO로 묶어 전달하게 수정
  * User context를 User 타입으로 감싸 일관성 있는 명확한 의도를 표현
  * Primitive 타입 대신 object로 강제하여 값의 안정성 보장
  * 추후 user context에 다른 값들이 추가되어도 변경점 최소화
* import 와일드카드 제거
* PathVariable로 전달받는 값에 validation 추가