### PR TITLE
feat: QnA authorization with service-level checks

### DIFF
--- a/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/QnaController.java
@@ -1,5 +1,6 @@
 package com.example.lxp.qna.adapter.in.web;
 
+import com.example.lxp.common.auth.model.User;
 import com.example.lxp.qna.adapter.in.web.dto.AddAnswerRequest;
 import com.example.lxp.qna.adapter.in.web.dto.CreateQuestionRequest;
 import com.example.lxp.qna.adapter.in.web.dto.UpdateQuestionRequest;
@@ -9,15 +10,28 @@ import com.example.lxp.qna.application.port.in.dto.CreateQuestionCommand;
 import com.example.lxp.qna.application.port.in.dto.DeleteQuestionCommand;
 import com.example.lxp.qna.application.port.in.dto.UpdateQuestionCommand;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+
+@Validated
 @RestController
 @RequestMapping("/api/courses/{courseId}/lessons/{lessonId}/qna")
 public class QnaController {
 
     private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
 
     private final QuestionCommandUseCase questionCommandUseCase;
 
@@ -27,17 +41,19 @@ public class QnaController {
 
     @PostMapping
     public ResponseEntity<Void> createQuestion(
-            @PathVariable Long courseId,
-            @PathVariable Long lessonId,
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long lessonId,
             @RequestBody @Valid CreateQuestionRequest body,
-            @RequestHeader(HEADER_USER_ID) Long userId
+            @RequestHeader(HEADER_USER_ID) @Positive Long userId,
+            @RequestHeader(HEADER_USER_ROLE) @NotNull String userRole
     ) {
+        User user = User.from(userId, userRole);
         CreateQuestionCommand command = new CreateQuestionCommand(
                 courseId,
                 lessonId,
                 body.title(),
                 body.content(),
-                userId
+                user
         );
         questionCommandUseCase.createQuestion(command);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -45,15 +61,17 @@ public class QnaController {
 
     @PostMapping("/{questionId}/replies")
     public ResponseEntity<Void> addAnswer(
-            @PathVariable Long courseId,
-            @PathVariable Long lessonId,
-            @PathVariable Long questionId,
+            @PathVariable @Positive Long courseId,
+            @PathVariable @Positive Long lessonId,
+            @PathVariable @Positive Long questionId,
             @RequestBody @Valid AddAnswerRequest body,
-            @RequestHeader(HEADER_USER_ID) Long userId
+            @RequestHeader(HEADER_USER_ID) @Positive Long userId,
+            @RequestHeader(HEADER_USER_ROLE) @NotNull String userRole
     ) {
+        User user = User.from(userId, userRole);
         AddAnswerCommand command = new AddAnswerCommand(
                 questionId,
-                userId,
+                user,
                 body.content(),
                 courseId,
                 lessonId
@@ -64,15 +82,17 @@ public class QnaController {
 
     @PatchMapping("/{questionId}")
     public ResponseEntity<Void> updateQuestion(
-            @PathVariable Long questionId,
+            @PathVariable @Positive Long questionId,
             @RequestBody UpdateQuestionRequest body,
-            @RequestHeader(HEADER_USER_ID) Long userId
+            @RequestHeader(HEADER_USER_ID) @Positive Long userId,
+            @RequestHeader(HEADER_USER_ROLE) @NotNull String userRole
     ) {
+        User user = User.from(userId, userRole);
         UpdateQuestionCommand command = new UpdateQuestionCommand(
                 questionId,
                 body.title(),
                 body.content(),
-                userId
+                user
         );
         questionCommandUseCase.updateQuestion(command);
         return ResponseEntity.ok().build();
@@ -80,12 +100,14 @@ public class QnaController {
 
     @DeleteMapping("/{questionId}")
     public ResponseEntity<Void> deleteQuestion(
-            @PathVariable Long questionId,
-            @RequestHeader(HEADER_USER_ID) Long userId
+            @PathVariable @Positive Long questionId,
+            @RequestHeader(HEADER_USER_ID) @Positive Long userId,
+            @RequestHeader(HEADER_USER_ROLE) @NotNull String userRole
     ) {
+        User user = User.from(userId, userRole);
         DeleteQuestionCommand command = new DeleteQuestionCommand(
                 questionId,
-                userId
+                user
         );
         questionCommandUseCase.deleteQuestion(command);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/QnaEnrollmentClient.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/QnaEnrollmentClient.java
@@ -1,20 +1,20 @@
-package com.example.lxp.review.adapter.out.external;
+package com.example.lxp.qna.adapter.out.external;
 
-import com.example.lxp.review.adapter.out.external.dto.EnrollmentCheckResponse;
+import com.example.lxp.qna.adapter.out.external.dto.QnaEnrollmentCheckResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
-        name = "enrollment-api",
+        name = "qna-enrollment-api",
         url = "${enrollment-api.url:http://localhost:8080}"
 )
-public interface EnrollmentClient {
+public interface QnaEnrollmentClient {
 
     @GetMapping("/api/enrollments")
-    EnrollmentCheckResponse isEnrolled(
+    QnaEnrollmentCheckResponse isEnrolled(
             @RequestParam Long courseId,
-            @RequestParam Long instructorId
+            @RequestParam Long userId
     );
 
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/QnaEnrollmentClientAdapter.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/QnaEnrollmentClientAdapter.java
@@ -1,0 +1,22 @@
+package com.example.lxp.qna.adapter.out.external;
+
+import com.example.lxp.qna.adapter.out.external.dto.QnaEnrollmentCheckResponse;
+import com.example.lxp.qna.application.port.out.EnrollmentClientPort;
+import org.springframework.stereotype.Component;
+
+@Component("qnaEnrollmentClientAdapter")
+public class QnaEnrollmentClientAdapter implements EnrollmentClientPort {
+
+    private final QnaEnrollmentClient qnaEnrollmentClient;
+
+    public QnaEnrollmentClientAdapter(QnaEnrollmentClient qnaEnrollmentClient) {
+        this.qnaEnrollmentClient = qnaEnrollmentClient;
+    }
+
+    @Override
+    public boolean isEnrolled(Long courseId, Long userId) {
+        QnaEnrollmentCheckResponse response = qnaEnrollmentClient.isEnrolled(courseId, userId);
+        return response != null && Boolean.TRUE.equals(response.isEnrolled());
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/dto/CourseInstructorCheckResponse.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/dto/CourseInstructorCheckResponse.java
@@ -1,4 +1,6 @@
 package com.example.lxp.qna.adapter.out.external.dto;
 
-public record CourseInstructorCheckResponse(Boolean isInstructor) {
+public record CourseInstructorCheckResponse(
+        Boolean isInstructor
+) {
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/dto/QnaEnrollmentCheckResponse.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/dto/QnaEnrollmentCheckResponse.java
@@ -1,0 +1,6 @@
+package com.example.lxp.qna.adapter.out.external.dto;
+
+public record QnaEnrollmentCheckResponse(
+        Boolean isEnrolled
+) {
+}

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/AddAnswerCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/AddAnswerCommand.java
@@ -1,8 +1,10 @@
 package com.example.lxp.qna.application.port.in.dto;
 
+import com.example.lxp.common.auth.model.User;
+
 public record AddAnswerCommand(
     Long rootQuestionId,
-    Long authorId,
+    User user,
     String content,
     Long courseId,
     Long lessonId

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/CreateQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/CreateQuestionCommand.java
@@ -1,10 +1,12 @@
 package com.example.lxp.qna.application.port.in.dto;
 
+import com.example.lxp.common.auth.model.User;
+
 public record CreateQuestionCommand(
         Long courseId,
         Long lessonId,
         String title,
         String comment,
-        Long authorId
+        User user
 ) {
 }

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/DeleteQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/DeleteQuestionCommand.java
@@ -1,7 +1,9 @@
 package com.example.lxp.qna.application.port.in.dto;
 
+import com.example.lxp.common.auth.model.User;
+
 public record DeleteQuestionCommand(
         Long questionId,
-        Long authorId
+        User user
 ) {
 }

--- a/src/main/java/com/example/lxp/qna/application/port/in/dto/UpdateQuestionCommand.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/dto/UpdateQuestionCommand.java
@@ -1,9 +1,11 @@
 package com.example.lxp.qna.application.port.in.dto;
 
+import com.example.lxp.common.auth.model.User;
+
 public record UpdateQuestionCommand(
         Long questionId,
         String title,
         String comment,
-        Long authorId
+        User user
 ) {
 }

--- a/src/main/java/com/example/lxp/qna/application/port/out/EnrollmentClientPort.java
+++ b/src/main/java/com/example/lxp/qna/application/port/out/EnrollmentClientPort.java
@@ -1,0 +1,7 @@
+package com.example.lxp.qna.application.port.out;
+
+public interface EnrollmentClientPort {
+
+    boolean isEnrolled(Long courseId, Long userId);
+
+}

--- a/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
+++ b/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
@@ -1,5 +1,7 @@
 package com.example.lxp.qna.application.service;
 
+import com.example.lxp.common.auth.model.Role;
+import com.example.lxp.common.auth.model.User;
 import com.example.lxp.common.messaging.port.out.EventPublisherPort;
 import com.example.lxp.exception.BusinessException;
 import com.example.lxp.qna.application.port.in.QuestionCommandUseCase;
@@ -8,6 +10,7 @@ import com.example.lxp.qna.application.port.in.dto.CreateQuestionCommand;
 import com.example.lxp.qna.application.port.in.dto.DeleteQuestionCommand;
 import com.example.lxp.qna.application.port.in.dto.UpdateQuestionCommand;
 import com.example.lxp.qna.application.port.out.CourseClientPort;
+import com.example.lxp.qna.application.port.out.EnrollmentClientPort;
 import com.example.lxp.qna.application.port.out.QnaPersistencePort;
 import com.example.lxp.qna.domain.event.QuestionCreatedEvent;
 import com.example.lxp.qna.domain.model.Question;
@@ -24,15 +27,18 @@ public class QnaCommandService implements QuestionCommandUseCase {
     private final QnaPersistencePort qnaPersistencePort;
     private final EventPublisherPort publishEventPort;
     private final CourseClientPort courseClientPort;
+    private final EnrollmentClientPort enrollmentClientPort;
 
     public QnaCommandService(
             QnaPersistencePort qnaPersistencePort,
             EventPublisherPort publishEventPort,
-            CourseClientPort courseClientPort
+            CourseClientPort courseClientPort,
+            EnrollmentClientPort enrollmentClientPort
     ) {
         this.qnaPersistencePort = qnaPersistencePort;
         this.publishEventPort = publishEventPort;
         this.courseClientPort = courseClientPort;
+        this.enrollmentClientPort = enrollmentClientPort;
     }
 
     @Override
@@ -40,7 +46,7 @@ public class QnaCommandService implements QuestionCommandUseCase {
         Question question = Question.createRoot(
                 command.courseId(),
                 command.lessonId(),
-                command.authorId(),
+                command.user().getId(),
                 command.title(),
                 command.comment()
         );
@@ -64,16 +70,14 @@ public class QnaCommandService implements QuestionCommandUseCase {
             throw BusinessException.builder(QnaErrorCode.CANNOT_REPLY_TO_REPLY).build();
         }
 
-        if (!canReply(parentQuestion, command.authorId())) {
-            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_REPLY).build();
-        }
+        validateAnswerPermission(parentQuestion, command.user());
 
         Question reply = Question.createReply(
                 command.rootQuestionId(),
                 parentQuestion.getThreadId(),
                 command.courseId(),
                 command.lessonId(),
-                command.authorId(),
+                command.user().getId(),
                 command.content()
         );
 
@@ -87,11 +91,9 @@ public class QnaCommandService implements QuestionCommandUseCase {
         Question question = qnaPersistencePort.findById(command.questionId())
                 .orElseThrow(() -> BusinessException.builder(QnaErrorCode.QUESTION_NOT_FOUND).build());
 
-        question.update(
-                command.authorId(),
-                command.title(),
-                command.comment()
-        );
+        validateQuestionModification(question, command.user());
+
+        question.update(command.title(), command.comment());
 
         return qnaPersistencePort.save(question);
     }
@@ -101,7 +103,9 @@ public class QnaCommandService implements QuestionCommandUseCase {
         Question question = qnaPersistencePort.findById(command.questionId())
                 .orElseThrow(() -> BusinessException.builder(QnaErrorCode.QUESTION_NOT_FOUND).build());
 
-        question.delete(command.authorId());
+        validateQuestionModification(question, command.user());
+
+        question.delete();
         if (question.getRootId() == null) {
             qnaPersistencePort.deleteByThreadId(question.getThreadId());
         } else {
@@ -109,10 +113,29 @@ public class QnaCommandService implements QuestionCommandUseCase {
         }
     }
 
-    private boolean canReply(Question rootQuestion, Long replierId) {
-        boolean isRootAuthor = Objects.equals(rootQuestion.getAuthorId(), replierId);
-        boolean isInstructor = courseClientPort.isInstructor(rootQuestion.getCourseId(), replierId);
-        return isRootAuthor || isInstructor;
+    private void validateQuestionModification(Question question, User user) {
+        if (user.getRole() == Role.ADMIN) {
+            return;
+        }
+        if (!question.isAuthor(user.getId())) {
+            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
+        }
+    }
+
+    private void validateAnswerPermission(Question rootQuestion, User user) {
+        if (user.getRole() == Role.ADMIN) {
+            return;
+        }
+
+        boolean isInstructor = courseClientPort.isInstructor(rootQuestion.getCourseId(), user.getId());
+        if (isInstructor) {
+            return;
+        }
+
+        boolean isEnrolled = enrollmentClientPort.isEnrolled(rootQuestion.getCourseId(), user.getId());
+        if (!isEnrolled) {
+            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_REPLY).build();
+        }
     }
 
 }

--- a/src/main/java/com/example/lxp/qna/domain/model/Question.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/Question.java
@@ -2,7 +2,18 @@ package com.example.lxp.qna.domain.model;
 
 import com.example.lxp.exception.BusinessException;
 import com.example.lxp.qna.exception.QnaErrorCode;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -88,10 +99,7 @@ public class Question {
 
     // Business Logics ----------
 
-    public void update(Long userId, String title, String content) {
-        if (!isAuthor(userId)) {
-            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
-        }
+    public void update(String title, String content) {
         if (title != null && !title.isBlank()) {
             this.title = title;
         }
@@ -100,20 +108,12 @@ public class Question {
         }
     }
 
-    // Soft Delete 및 질문의 상태 변화 구현시 사용 예정
-    public void delete(Long userId) {
-        if (!isAuthor(userId)) {
-            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
-        }
+    public void delete() {
         this.status = QuestionStatus.DELETED;
     }
 
-    // MVP-002: 추후 업데이트로 질문의 상태 변화에 대한 코드 적용 예정
-    public void resolve(Long userId) {
-        if (!isAuthor(userId)) {
-            throw BusinessException.builder(QnaErrorCode.FORBIDDEN_QUESTION_MODIFICATION).build();
-        }
-        if (this.rootId != null) { // This question is a reply
+    public void resolve() {
+        if (this.rootId != null) {
             throw BusinessException.builder(QnaErrorCode.CANNOT_RESOLVE_REPLY).build();
         }
         this.status = QuestionStatus.RESOLVED;
@@ -121,7 +121,7 @@ public class Question {
 
     // Helper Methods ----------
 
-    private boolean isAuthor(Long userId) {
+    public boolean isAuthor(Long userId) {
         return Objects.equals(this.authorId, userId);
     }
 

--- a/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
@@ -1,6 +1,5 @@
 package com.example.lxp.review.adapter.in.web;
 
-import com.example.lxp.common.auth.model.Role;
 import com.example.lxp.common.auth.model.User;
 import com.example.lxp.review.adapter.in.web.dto.CreateReviewRequest;
 import com.example.lxp.review.adapter.in.web.dto.UpdateReviewRequest;
@@ -47,7 +46,7 @@ public class ReviewController {
     ) {
         CreateReviewCommand command = new CreateReviewCommand(
                 courseId,
-                new User(userId, Role.valueOf(userRole)),
+                User.from(userId, userRole),
                 request.title(),
                 request.comment(),
                 Rating.of(request.stars())
@@ -67,7 +66,7 @@ public class ReviewController {
         UpdateReviewCommand command = new UpdateReviewCommand(
                 courseId,
                 reviewId,
-                new User(userId, Role.valueOf(userRole)),
+                User.from(userId, userRole),
                 request.title(),
                 request.comment(),
                 Rating.of(request.stars())
@@ -86,7 +85,7 @@ public class ReviewController {
         DeleteReviewCommand command = new DeleteReviewCommand(
                 courseId,
                 reviewId,
-                new User(userId, Role.valueOf(userRole))
+                User.from(userId, userRole)
         );
         reviewCommandUseCase.deleteReview(command);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/lxp/review/adapter/out/external/ReviewEnrollmentClient.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/ReviewEnrollmentClient.java
@@ -1,0 +1,20 @@
+package com.example.lxp.review.adapter.out.external;
+
+import com.example.lxp.review.adapter.out.external.dto.ReviewEnrollmentCheckResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "review-enrollment-api",
+        url = "${enrollment-api.url:http://localhost:8080}"
+)
+public interface ReviewEnrollmentClient {
+
+    @GetMapping("/api/enrollments")
+    ReviewEnrollmentCheckResponse isEnrolled(
+            @RequestParam Long courseId,
+            @RequestParam Long userId
+    );
+
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/external/ReviewEnrollmentClientAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/ReviewEnrollmentClientAdapter.java
@@ -1,21 +1,21 @@
 package com.example.lxp.review.adapter.out.external;
 
-import com.example.lxp.review.adapter.out.external.dto.EnrollmentCheckResponse;
+import com.example.lxp.review.adapter.out.external.dto.ReviewEnrollmentCheckResponse;
 import com.example.lxp.review.application.port.out.EnrollmentClientPort;
 import org.springframework.stereotype.Component;
 
 @Component
-public class EnrollmentClientAdapter implements EnrollmentClientPort {
+public class ReviewEnrollmentClientAdapter implements EnrollmentClientPort {
 
-    private final EnrollmentClient enrollmentClient;
+    private final ReviewEnrollmentClient enrollmentClient;
 
-    public EnrollmentClientAdapter(EnrollmentClient enrollmentClient) {
+    public ReviewEnrollmentClientAdapter(ReviewEnrollmentClient enrollmentClient) {
         this.enrollmentClient = enrollmentClient;
     }
 
     @Override
     public boolean isEnrolled(Long courseId, Long userId) {
-        EnrollmentCheckResponse response = enrollmentClient.isEnrolled(courseId, userId);
+        ReviewEnrollmentCheckResponse response = enrollmentClient.isEnrolled(courseId, userId);
         return response != null && Boolean.TRUE.equals(response.isEnrolled());
     }
 

--- a/src/main/java/com/example/lxp/review/adapter/out/external/dto/EnrollmentCheckResponse.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/dto/EnrollmentCheckResponse.java
@@ -1,4 +1,0 @@
-package com.example.lxp.review.adapter.out.external.dto;
-
-public record EnrollmentCheckResponse(Boolean isEnrolled) {
-}

--- a/src/main/java/com/example/lxp/review/adapter/out/external/dto/ReviewEnrollmentCheckResponse.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/dto/ReviewEnrollmentCheckResponse.java
@@ -1,0 +1,6 @@
+package com.example.lxp.review.adapter.out.external.dto;
+
+public record ReviewEnrollmentCheckResponse(
+        Boolean isEnrolled
+) {
+}

--- a/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
@@ -39,14 +39,14 @@ public class ReviewCommandService implements ReviewCommandUseCase, ReviewIntegra
     @Override
     public void createReview(CreateReviewCommand command) {
         // EXTERNAL: OUTGOING
-        if (!enrollmentClientPort.isEnrolled(command.courseId(), command.user().id())) {
+        if (!enrollmentClientPort.isEnrolled(command.courseId(), command.user().getId())) {
             throw BusinessException.builder(ReviewErrorCode.USER_NOT_ENROLLED_IN_COURSE).build();
         }
-        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.user().id(), command.courseId()).isPresent()) {
+        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.user().getId(), command.courseId()).isPresent()) {
             throw BusinessException.builder(ReviewErrorCode.REVIEW_ALREADY_EXISTS).build();
         }
         Review review = Review.create(
-                command.user().id(),
+                command.user().getId(),
                 command.courseId(),
                 command.title(),
                 command.comment(),
@@ -59,10 +59,10 @@ public class ReviewCommandService implements ReviewCommandUseCase, ReviewIntegra
 
     @Override
     public void updateReview(UpdateReviewCommand command) {
-        Review review = findAndValidateReview(command.reviewId(), command.user().id(), command.courseId());
+        Review review = findAndValidateReview(command.reviewId(), command.user().getId(), command.courseId());
 
         review.update(
-                command.user().id(),
+                command.user().getId(),
                 command.title(),
                 command.comment(),
                 command.rating()
@@ -74,7 +74,7 @@ public class ReviewCommandService implements ReviewCommandUseCase, ReviewIntegra
 
     @Override
     public void deleteReview(DeleteReviewCommand command) {
-        Review review = findAndValidateReview(command.reviewId(), command.user().id(), command.courseId());
+        Review review = findAndValidateReview(command.reviewId(), command.user().getId(), command.courseId());
 
         reviewPersistencePort.delete(review);
 

--- a/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
@@ -42,7 +42,7 @@ public class ReviewCommandService implements ReviewCommandUseCase, ReviewIntegra
         if (!enrollmentClientPort.isEnrolled(command.courseId(), command.user().getId())) {
             throw BusinessException.builder(ReviewErrorCode.USER_NOT_ENROLLED_IN_COURSE).build();
         }
-        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.user().getId(), command.courseId()).isPresent()) {
+        if (reviewPersistencePort.findByCourseIdAndAuthorId(command.courseId(), command.user().getId()).isPresent()) {
             throw BusinessException.builder(ReviewErrorCode.REVIEW_ALREADY_EXISTS).build();
         }
         Review review = Review.create(

--- a/src/main/java/com/example/lxp/review/domain/event/ReviewDeletedEvent.java
+++ b/src/main/java/com/example/lxp/review/domain/event/ReviewDeletedEvent.java
@@ -6,7 +6,7 @@ import com.example.lxp.review.domain.model.Review;
 public class ReviewDeletedEvent implements DomainEvent {
 
     private static final String SERVICE_PREFIX = "review";
-    private static final String EVENT_NAME = "review-created";
+    private static final String EVENT_NAME = "review-deleted";
 
     private final long reviewId;
     private final long courseId;

--- a/src/main/java/com/example/lxp/review/domain/model/Rating.java
+++ b/src/main/java/com/example/lxp/review/domain/model/Rating.java
@@ -21,7 +21,7 @@ public class Rating {
     }
 
     public static Rating of(Integer stars) {
-        if (stars != null && (stars < RATING_MIN || stars > RATING_MAX)) {
+        if (stars == null || (stars < RATING_MIN || stars > RATING_MAX)) {
             throw BusinessException.builder(ReviewErrorCode.RATING_OUT_OF_RANGE).build();
         }
         return new Rating(stars);


### PR DESCRIPTION
- QnA 영역에서 User VO를 적용하고, Command → Service → Entity 흐름을 재정비
- 서비스 레이어가 모든 권한 검증을 담당하도록 분리하고, 엔티티는 상태 변경만 수행하도록 리팩터링
- Course/Enrollment 외부 API 연동 구조를 정리하고, 에러 메시지를 한국어로 통일
- 공통 인증 오류 코드를 추가해 인증 컨텍스트 문제를 일관되게 처리