### PR TITLE
feat: message handling on async message from internal services

### DIFF
--- a/src/main/java/com/example/lxp/review/adapter/in/messaging/rabbit/ReviewRabbitEventSubscriber.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/messaging/rabbit/ReviewRabbitEventSubscriber.java
@@ -7,6 +7,8 @@ import com.example.lxp.review.application.port.in.ReviewIntegrationUseCase;
 import com.example.lxp.review.application.port.in.dto.DeleteReviewsByCourseCommand;
 import com.example.lxp.review.application.port.in.dto.DeleteReviewsByUserCommand;
 import com.rabbitmq.client.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -16,6 +18,8 @@ import java.io.IOException;
 
 @Component
 public class ReviewRabbitEventSubscriber {
+
+    private static final Logger log = LoggerFactory.getLogger(ReviewRabbitEventSubscriber.class);
 
     private final ReviewIntegrationUseCase reviewIntegrationUseCase;
 
@@ -31,7 +35,7 @@ public class ReviewRabbitEventSubscriber {
     ) throws IOException {
         long deliveryTag = message.getMessageProperties().getDeliveryTag();
         try {
-            System.out.printf("Review Service consume: routingKey=%s messageId=%s traceId=%s%n",
+            log.info("Review Service consume: routingKey={} messageId={} traceId={}",
                     message.getMessageProperties().getReceivedRoutingKey(),
                     envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
                     envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
@@ -39,7 +43,7 @@ public class ReviewRabbitEventSubscriber {
             reviewIntegrationUseCase.deleteReviewsByCourseId(command);
             channel.basicAck(deliveryTag, false);
         } catch (Exception e) {
-            System.err.printf("Review Service handler error: %s%n", e.getMessage());
+            log.error("Review Service handler error: {}", e.getMessage(), e);
             channel.basicNack(deliveryTag, false, false);
         }
 
@@ -53,7 +57,7 @@ public class ReviewRabbitEventSubscriber {
     ) throws IOException {
         long deliveryTag = message.getMessageProperties().getDeliveryTag();
         try {
-            System.out.printf("Review Service consume: routingKey=%s messageId=%s traceId=%s%n",
+            log.info("Review Service consume: routingKey={} messageId={} traceId={}",
                     message.getMessageProperties().getReceivedRoutingKey(),
                     envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
                     envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
@@ -62,7 +66,7 @@ public class ReviewRabbitEventSubscriber {
             reviewIntegrationUseCase.deleteReviewsByAuthorId(command);
             channel.basicAck(deliveryTag, false);
         } catch (Exception e) {
-            System.err.printf("Review Service handler error: %s%n", e.getMessage());
+            log.error("Review Service handler error: {}", e.getMessage(), e);
             channel.basicNack(deliveryTag, false, false);
         }
     }

--- a/src/main/java/com/example/lxp/review/adapter/in/messaging/rabbit/ReviewRabbitEventSubscriber.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/messaging/rabbit/ReviewRabbitEventSubscriber.java
@@ -4,6 +4,8 @@ import com.example.lxp.common.messaging.domain.model.EventEnvelope;
 import com.example.lxp.review.adapter.in.messaging.rabbit.dto.CourseDeletedEvent;
 import com.example.lxp.review.adapter.in.messaging.rabbit.dto.UserDeletedEvent;
 import com.example.lxp.review.application.port.in.ReviewIntegrationUseCase;
+import com.example.lxp.review.application.port.in.dto.DeleteReviewsByCourseCommand;
+import com.example.lxp.review.application.port.in.dto.DeleteReviewsByUserCommand;
 import com.rabbitmq.client.Channel;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -33,7 +35,8 @@ public class ReviewRabbitEventSubscriber {
                     message.getMessageProperties().getReceivedRoutingKey(),
                     envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
                     envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
-            System.out.println(envelope.getPayload().toString());
+            DeleteReviewsByCourseCommand command = new DeleteReviewsByCourseCommand(envelope.getPayload().courseId());
+            reviewIntegrationUseCase.deleteReviewsByCourseId(command);
             channel.basicAck(deliveryTag, false);
         } catch (Exception e) {
             System.err.printf("Review Service handler error: %s%n", e.getMessage());
@@ -48,7 +51,20 @@ public class ReviewRabbitEventSubscriber {
             Message message,
             Channel channel
     ) throws IOException {
-        // TODO: Implement
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            System.out.printf("Review Service consume: routingKey=%s messageId=%s traceId=%s%n",
+                    message.getMessageProperties().getReceivedRoutingKey(),
+                    envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
+                    envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
+            Long authorId = envelope.getPayload().userId();
+            DeleteReviewsByUserCommand command = new DeleteReviewsByUserCommand(authorId);
+            reviewIntegrationUseCase.deleteReviewsByAuthorId(command);
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            System.err.printf("Review Service handler error: %s%n", e.getMessage());
+            channel.basicNack(deliveryTag, false, false);
+        }
     }
 
 }

--- a/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewPersistenceAdapter.java
@@ -50,5 +50,10 @@ public class ReviewPersistenceAdapter implements ReviewPersistencePort {
     public void deleteAllByCourseId(Long courseId) {
         reviewRepository.deleteAllByCourseId(courseId);
     }
-    
+
+    @Override
+    public void deleteAllByAuthorId(Long authorId) {
+        reviewRepository.deleteAllByAuthorId(authorId);
+    }
+
 }

--- a/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewRepository.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewRepository.java
@@ -16,4 +16,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     void deleteAllByCourseId(Long courseId);
 
+    void deleteAllByAuthorId(Long authorId);
+
 }

--- a/src/main/java/com/example/lxp/review/application/port/in/ReviewIntegrationUseCase.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/ReviewIntegrationUseCase.java
@@ -1,9 +1,12 @@
 package com.example.lxp.review.application.port.in;
 
 import com.example.lxp.review.application.port.in.dto.DeleteReviewsByCourseCommand;
+import com.example.lxp.review.application.port.in.dto.DeleteReviewsByUserCommand;
 
 public interface ReviewIntegrationUseCase {
 
-    void deleteReviewsByCourseId(DeleteReviewsByCourseCommand event);
+    void deleteReviewsByCourseId(DeleteReviewsByCourseCommand command);
+
+    void deleteReviewsByAuthorId(DeleteReviewsByUserCommand command);
 
 }

--- a/src/main/java/com/example/lxp/review/application/port/in/dto/DeleteReviewsByUserCommand.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/dto/DeleteReviewsByUserCommand.java
@@ -1,0 +1,8 @@
+package com.example.lxp.review.application.port.in.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteReviewsByUserCommand(
+        @NotNull Long authorId
+) {
+}

--- a/src/main/java/com/example/lxp/review/application/port/out/ReviewPersistencePort.java
+++ b/src/main/java/com/example/lxp/review/application/port/out/ReviewPersistencePort.java
@@ -21,4 +21,6 @@ public interface ReviewPersistencePort {
 
     void deleteAllByCourseId(Long courseId);
 
+    void deleteAllByAuthorId(Long authorId);
+
 }

--- a/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
+++ b/src/main/java/com/example/lxp/review/application/service/ReviewCommandService.java
@@ -7,6 +7,7 @@ import com.example.lxp.review.application.port.in.ReviewIntegrationUseCase;
 import com.example.lxp.review.application.port.in.dto.CreateReviewCommand;
 import com.example.lxp.review.application.port.in.dto.DeleteReviewCommand;
 import com.example.lxp.review.application.port.in.dto.DeleteReviewsByCourseCommand;
+import com.example.lxp.review.application.port.in.dto.DeleteReviewsByUserCommand;
 import com.example.lxp.review.application.port.in.dto.UpdateReviewCommand;
 import com.example.lxp.review.application.port.out.EnrollmentClientPort;
 import com.example.lxp.review.application.port.out.ReviewPersistencePort;
@@ -84,6 +85,11 @@ public class ReviewCommandService implements ReviewCommandUseCase, ReviewIntegra
     @Override
     public void deleteReviewsByCourseId(DeleteReviewsByCourseCommand command) {
         reviewPersistencePort.deleteAllByCourseId(command.courseId());
+    }
+
+    @Override
+    public void deleteReviewsByAuthorId(DeleteReviewsByUserCommand command) {
+        reviewPersistencePort.deleteAllByAuthorId(command.authorId());
     }
 
     private Review findAndValidateReview(Long reviewId, Long authorId, Long courseId) {


### PR DESCRIPTION
user-deleted / course-deleted 메시지 수신 후 조건에 해당되는 review 삭제하는 플로우 구현

이벤트 명칭 / routing key는 추후 convention 확립 후 수정 가능성을 염두에 두었음

작동 흐름 예시:
RabbitMQ (user.user-deleted.event)
    ↓
ReviewRabbitEventSubscriber.handleUserDeleted
    ↓ 
DeleteReviewsByUserCommand
    ↓
ReviewIntegrationUseCase.deleteReviewsByAuthorId
    ↓
ReviewCommandService.deleteReviewsByAuthorId
    ↓
ReviewPersistencePort.deleteAllByAuthorId
    ↓
ReviewRepository.deleteAllByAuthorId
    ↓
DB: DELETE FROM review WHERE author_id = ?