### PR TITLE
feat: refactor Question domain + additional external API call safety

### DIFF
--- a/src/main/java/com/example/lxp/exception/ExternalServiceErrorCode.java
+++ b/src/main/java/com/example/lxp/exception/ExternalServiceErrorCode.java
@@ -1,0 +1,42 @@
+package com.example.lxp.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ExternalServiceErrorCode implements ErrorCode {
+
+    DEPENDENCY_TIMEOUT("EXT-0001", HttpStatus.GATEWAY_TIMEOUT, "외부 서비스 응답 시간 초과"),
+    DEPENDENCY_UNAVAILABLE("EXT-0002", HttpStatus.SERVICE_UNAVAILABLE, "외부 서비스 연결 불가"),
+    DEPENDENCY_BAD_RESPONSE("EXT-0003", HttpStatus.BAD_GATEWAY, "외부 서비스 응답 오류"),
+    DEPENDENCY_CONTRACT_ERROR("EXT-0004", HttpStatus.INTERNAL_SERVER_ERROR, "외부 서비스 계약 위반");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ExternalServiceErrorCode(String code, HttpStatus status, String message) {
+        this.code = code;
+        this.httpStatus = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/QnaRabbitEventSubscriber.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/QnaRabbitEventSubscriber.java
@@ -1,0 +1,122 @@
+package com.example.lxp.qna.adapter.in.messaging.rabbit;
+
+import com.example.lxp.common.messaging.domain.model.EventEnvelope;
+import com.example.lxp.qna.adapter.in.messaging.rabbit.dto.ChapterDeletedEvent;
+import com.example.lxp.qna.adapter.in.messaging.rabbit.dto.CourseDeletedEvent;
+import com.example.lxp.qna.adapter.in.messaging.rabbit.dto.LessonDeletedEvent;
+import com.example.lxp.qna.adapter.in.messaging.rabbit.dto.UserDeletedEvent;
+import com.rabbitmq.client.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class QnaRabbitEventSubscriber {
+
+    private static final Logger log = LoggerFactory.getLogger(QnaRabbitEventSubscriber.class);
+
+    // TODO: 삭제 전파 정책 확정 후 QnaIntegrationUseCase 주입 및 구현
+    // private final QnaIntegrationUseCase qnaIntegrationUseCase;
+
+    @RabbitListener(queues = "${rabbit.services.qna.queues.course-deleted.name}", ackMode = "MANUAL")
+    public void handleCourseDeleted(
+            @Payload EventEnvelope<CourseDeletedEvent> envelope,
+            Message message,
+            Channel channel
+    ) throws IOException {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            log.info("QNA Service consume: routingKey={} messageId={} traceId={}",
+                    message.getMessageProperties().getReceivedRoutingKey(),
+                    envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
+                    envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
+
+            // TODO: 삭제 전파 정책 확정 후 구현
+            // Long courseId = envelope.getPayload().courseId();
+            // qnaIntegrationUseCase.deleteQuestionsByCourseId(courseId);
+
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            log.error("QNA Service handler error: {}", e.getMessage(), e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+
+    @RabbitListener(queues = "${rabbit.services.qna.queues.chapter-deleted.name}", ackMode = "MANUAL")
+    public void handleChapterDeleted(
+            @Payload EventEnvelope<ChapterDeletedEvent> envelope,
+            Message message,
+            Channel channel
+    ) throws IOException {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            log.info("QNA Service consume: routingKey={} messageId={} traceId={}",
+                    message.getMessageProperties().getReceivedRoutingKey(),
+                    envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
+                    envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
+
+            // TODO: 삭제 전파 정책 확정 후 구현
+            // List<Long> lessonIds = envelope.getPayload().lessonIds();
+            // qnaIntegrationUseCase.deleteQuestionsByLessonIds(lessonIds);
+
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            log.error("QNA Service handler error: {}", e.getMessage(), e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+
+    @RabbitListener(queues = "${rabbit.services.qna.queues.lesson-deleted.name}", ackMode = "MANUAL")
+    public void handleLessonDeleted(
+            @Payload EventEnvelope<LessonDeletedEvent> envelope,
+            Message message,
+            Channel channel
+    ) throws IOException {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            log.info("QNA Service consume: routingKey={} messageId={} traceId={}",
+                    message.getMessageProperties().getReceivedRoutingKey(),
+                    envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
+                    envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
+
+            // TODO: 삭제 전파 정책 확정 후 구현
+            // Long lessonId = envelope.getPayload().lessonId();
+            // qnaIntegrationUseCase.deleteQuestionsByLessonId(lessonId);
+
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            log.error("QNA Service handler error: {}", e.getMessage(), e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+
+    @RabbitListener(queues = "${rabbit.services.qna.queues.user-deleted.name}", ackMode = "MANUAL")
+    public void handleUserDeleted(
+            @Payload EventEnvelope<UserDeletedEvent> envelope,
+            Message message,
+            Channel channel
+    ) throws IOException {
+        long deliveryTag = message.getMessageProperties().getDeliveryTag();
+        try {
+            log.info("QNA Service consume: routingKey={} messageId={} traceId={}",
+                    message.getMessageProperties().getReceivedRoutingKey(),
+                    envelope.getMetadata() != null ? envelope.getMetadata().getMessageId() : "n/a",
+                    envelope.getMetadata() != null ? envelope.getMetadata().getTraceId() : "n/a");
+
+            // TODO: 삭제 전파 정책 확정 후 구현
+            // Long authorId = envelope.getPayload().userId();
+            // qnaIntegrationUseCase.deleteQuestionsByAuthorId(authorId);
+
+            channel.basicAck(deliveryTag, false);
+        } catch (Exception e) {
+            log.error("QNA Service handler error: {}", e.getMessage(), e);
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/ChapterDeletedEvent.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/ChapterDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.example.lxp.qna.adapter.in.messaging.rabbit.dto;
+
+import java.util.List;
+
+public record ChapterDeletedEvent(
+        Long chapterId,
+        List<Long> lessonIds
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/CourseDeletedEvent.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/CourseDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.example.lxp.qna.adapter.in.messaging.rabbit.dto;
+
+public record CourseDeletedEvent(
+        Long courseId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/LessonDeletedEvent.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/LessonDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.example.lxp.qna.adapter.in.messaging.rabbit.dto;
+
+public record LessonDeletedEvent(
+        Long lessonId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/UserDeletedEvent.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/messaging/rabbit/dto/UserDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.example.lxp.qna.adapter.in.messaging.rabbit.dto;
+
+public record UserDeletedEvent(
+        Long userId
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/QnaInternalController.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/QnaInternalController.java
@@ -1,0 +1,42 @@
+package com.example.lxp.qna.adapter.in.web;
+
+import com.example.lxp.qna.adapter.in.web.dto.UnansweredQuestionsResponse;
+import com.example.lxp.qna.application.port.in.QuestionQueryUseCase;
+import com.example.lxp.qna.domain.model.Question;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RestController
+@RequestMapping("/internal/qna")
+public class QnaInternalController {
+
+    private static final int DEFAULT_LIMIT = 3;
+
+    private final QuestionQueryUseCase questionQueryUseCase;
+
+    public QnaInternalController(QuestionQueryUseCase questionQueryUseCase) {
+        this.questionQueryUseCase = questionQueryUseCase;
+    }
+
+    @GetMapping("/instructors/{instructorId}/unanswered")
+    public ResponseEntity<UnansweredQuestionsResponse> getUnansweredQuestions(
+            @PathVariable @Positive Long instructorId,
+            @RequestParam(defaultValue = "3") @Positive int limit
+    ) {
+        List<Question> questions = questionQueryUseCase.findUnansweredQuestionsForInstructor(
+                instructorId,
+                Math.min(limit, 10)
+        );
+        return ResponseEntity.ok(UnansweredQuestionsResponse.from(questions));
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/dto/AddAnswerRequest.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/dto/AddAnswerRequest.java
@@ -3,5 +3,6 @@ package com.example.lxp.qna.adapter.in.web.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record AddAnswerRequest(
-    @NotBlank String content
-) {}
+        @NotBlank String content
+) {
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UnansweredQuestionResponse.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UnansweredQuestionResponse.java
@@ -1,0 +1,27 @@
+package com.example.lxp.qna.adapter.in.web.dto;
+
+import com.example.lxp.qna.domain.model.Question;
+
+import java.time.Instant;
+
+public record UnansweredQuestionResponse(
+        Long questionId,
+        Long courseId,
+        Long lessonId,
+        String title,
+        Long authorId,
+        Instant lastActivityAt
+) {
+
+    public static UnansweredQuestionResponse from(Question question) {
+        return new UnansweredQuestionResponse(
+                question.getId(),
+                question.getCourseId(),
+                question.getLessonId(),
+                question.getTitle(),
+                question.getAuthorId(),
+                question.getLastActivityAt()
+        );
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UnansweredQuestionsResponse.java
+++ b/src/main/java/com/example/lxp/qna/adapter/in/web/dto/UnansweredQuestionsResponse.java
@@ -1,0 +1,18 @@
+package com.example.lxp.qna.adapter.in.web.dto;
+
+import com.example.lxp.qna.domain.model.Question;
+
+import java.util.List;
+
+public record UnansweredQuestionsResponse(
+        List<UnansweredQuestionResponse> questions
+) {
+
+    public static UnansweredQuestionsResponse from(List<Question> questions) {
+        List<UnansweredQuestionResponse> items = questions.stream()
+                .map(UnansweredQuestionResponse::from)
+                .toList();
+        return new UnansweredQuestionsResponse(items);
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/CourseClient.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/CourseClient.java
@@ -4,7 +4,6 @@ import com.example.lxp.qna.adapter.out.external.dto.CourseInstructorCheckRespons
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
         name = "course-api",
@@ -12,10 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 )
 public interface CourseClient {
 
-    @GetMapping("/api/courses/{courseId}")
-    CourseInstructorCheckResponse isInstructor(
-            @PathVariable Long courseId,
-            @RequestParam Long instructorId
-    );
+    @GetMapping("/api/courses/{courseId}/instructor")
+    CourseInstructorCheckResponse getInstructorId(@PathVariable Long courseId);
 
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/CourseClientAdapter.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/CourseClientAdapter.java
@@ -1,11 +1,19 @@
 package com.example.lxp.qna.adapter.out.external;
 
+import com.example.lxp.exception.BusinessException;
+import com.example.lxp.exception.ExternalServiceErrorCode;
 import com.example.lxp.qna.adapter.out.external.dto.CourseInstructorCheckResponse;
 import com.example.lxp.qna.application.port.out.CourseClientPort;
+import feign.FeignException;
+import feign.RetryableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CourseClientAdapter implements CourseClientPort {
+
+    private static final Logger log = LoggerFactory.getLogger(CourseClientAdapter.class);
 
     private final CourseClient courseClient;
 
@@ -14,9 +22,26 @@ public class CourseClientAdapter implements CourseClientPort {
     }
 
     @Override
-    public boolean isInstructor(Long courseId, Long userId) {
-        CourseInstructorCheckResponse response = courseClient.isInstructor(courseId, userId);
-        return response != null && Boolean.TRUE.equals(response.isInstructor());
+    public Long getInstructorId(Long courseId) {
+        try {
+            CourseInstructorCheckResponse response = courseClient.getInstructorId(courseId);
+            if (response == null || response.instructorId() == null) {
+                log.error("course-api getInstructorId returned null for courseId={}", courseId);
+                throw BusinessException.builder(ExternalServiceErrorCode.DEPENDENCY_CONTRACT_ERROR).build();
+            }
+            return response.instructorId();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RetryableException e) {
+            log.error("course-api getInstructorId timeout for courseId={}", courseId, e);
+            throw BusinessException.builder(ExternalServiceErrorCode.DEPENDENCY_TIMEOUT).withCause(e).build();
+        } catch (FeignException.ServiceUnavailable e) {
+            log.error("course-api getInstructorId unavailable for courseId={}", courseId, e);
+            throw BusinessException.builder(ExternalServiceErrorCode.DEPENDENCY_UNAVAILABLE).withCause(e).build();
+        } catch (FeignException e) {
+            log.error("course-api getInstructorId failed for courseId={}, status={}", courseId, e.status(), e);
+            throw BusinessException.builder(ExternalServiceErrorCode.DEPENDENCY_BAD_RESPONSE).withCause(e).build();
+        }
     }
 
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/dto/CourseInstructorCheckResponse.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/dto/CourseInstructorCheckResponse.java
@@ -1,6 +1,6 @@
 package com.example.lxp.qna.adapter.out.external.dto;
 
 public record CourseInstructorCheckResponse(
-        Boolean isInstructor
+        Long instructorId
 ) {
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaPersistenceAdapter.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaPersistenceAdapter.java
@@ -2,8 +2,11 @@ package com.example.lxp.qna.adapter.out.persistence;
 
 import com.example.lxp.qna.application.port.out.QnaPersistencePort;
 import com.example.lxp.qna.domain.model.Question;
+import com.example.lxp.qna.domain.model.QuestionStatus;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -34,4 +37,34 @@ public class QnaPersistenceAdapter implements QnaPersistencePort {
     public void deleteByThreadId(String threadId) {
         qnaRepository.deleteByThreadId(threadId);
     }
+
+    @Override
+    public void deleteAllByLessonId(Long lessonId) {
+        qnaRepository.deleteAllByLessonId(lessonId);
+    }
+
+    @Override
+    public void deleteAllByLessonIds(List<Long> lessonIds) {
+        qnaRepository.deleteAllByLessonIdIn(lessonIds);
+    }
+
+    @Override
+    public void deleteAllByCourseId(Long courseId) {
+        qnaRepository.deleteAllByCourseId(courseId);
+    }
+
+    @Override
+    public void deleteAllByAuthorId(Long authorId) {
+        qnaRepository.deleteAllByAuthorId(authorId);
+    }
+
+    @Override
+    public List<Question> findOpenedRootQuestionsByInstructorId(Long instructorId, int limit) {
+        return qnaRepository.findRootQuestionsByInstructorIdAndStatus(
+                instructorId,
+                QuestionStatus.OPENED,
+                PageRequest.of(0, limit)
+        );
+    }
+
 }

--- a/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaRepository.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/persistence/QnaRepository.java
@@ -1,9 +1,31 @@
 package com.example.lxp.qna.adapter.out.persistence;
 
 import com.example.lxp.qna.domain.model.Question;
+import com.example.lxp.qna.domain.model.QuestionStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface QnaRepository extends JpaRepository<Question, Long> {
 
     void deleteByThreadId(String threadId);
+
+    void deleteAllByLessonId(Long lessonId);
+
+    void deleteAllByLessonIdIn(List<Long> lessonIds);
+
+    void deleteAllByCourseId(Long courseId);
+
+    void deleteAllByAuthorId(Long authorId);
+
+    @Query("SELECT q FROM Question q WHERE q.instructorId = :instructorId AND q.rootId IS NULL AND q.status = :status ORDER BY q.lastActivityAt DESC")
+    List<Question> findRootQuestionsByInstructorIdAndStatus(
+            @Param("instructorId") Long instructorId,
+            @Param("status") QuestionStatus status,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/example/lxp/qna/application/port/in/QuestionQueryUseCase.java
+++ b/src/main/java/com/example/lxp/qna/application/port/in/QuestionQueryUseCase.java
@@ -1,0 +1,11 @@
+package com.example.lxp.qna.application.port.in;
+
+import com.example.lxp.qna.domain.model.Question;
+
+import java.util.List;
+
+public interface QuestionQueryUseCase {
+
+    List<Question> findUnansweredQuestionsForInstructor(Long instructorId, int limit);
+
+}

--- a/src/main/java/com/example/lxp/qna/application/port/out/CourseClientPort.java
+++ b/src/main/java/com/example/lxp/qna/application/port/out/CourseClientPort.java
@@ -2,6 +2,6 @@ package com.example.lxp.qna.application.port.out;
 
 public interface CourseClientPort {
 
-    boolean isInstructor(Long courseId, Long userId);
+    Long getInstructorId(Long courseId);
 
 }

--- a/src/main/java/com/example/lxp/qna/application/port/out/QnaPersistencePort.java
+++ b/src/main/java/com/example/lxp/qna/application/port/out/QnaPersistencePort.java
@@ -2,6 +2,7 @@ package com.example.lxp.qna.application.port.out;
 
 import com.example.lxp.qna.domain.model.Question;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface QnaPersistencePort {
@@ -13,5 +14,15 @@ public interface QnaPersistencePort {
     void delete(Question question);
 
     void deleteByThreadId(String threadId);
-    
+
+    void deleteAllByLessonId(Long lessonId);
+
+    void deleteAllByLessonIds(List<Long> lessonIds);
+
+    void deleteAllByCourseId(Long courseId);
+
+    void deleteAllByAuthorId(Long authorId);
+
+    List<Question> findOpenedRootQuestionsByInstructorId(Long instructorId, int limit);
+
 }

--- a/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
+++ b/src/main/java/com/example/lxp/qna/application/service/QnaCommandService.java
@@ -43,10 +43,13 @@ public class QnaCommandService implements QuestionCommandUseCase {
 
     @Override
     public Question createQuestion(CreateQuestionCommand command) {
+        Long instructorId = courseClientPort.getInstructorId(command.courseId());
+
         Question question = Question.createRoot(
                 command.courseId(),
                 command.lessonId(),
                 command.user().getId(),
+                instructorId,
                 command.title(),
                 command.comment()
         );
@@ -58,29 +61,37 @@ public class QnaCommandService implements QuestionCommandUseCase {
 
     @Override
     public Question addAnswer(AddAnswerCommand command) {
-        Question parentQuestion = qnaPersistencePort.findById(command.rootQuestionId())
+        Question rootQuestion = qnaPersistencePort.findById(command.rootQuestionId())
                 .orElseThrow(() -> BusinessException.builder(QnaErrorCode.QUESTION_NOT_FOUND).build());
 
-        if (!Objects.equals(parentQuestion.getCourseId(), command.courseId())
-                || !Objects.equals(parentQuestion.getLessonId(), command.lessonId())) {
+        if (!Objects.equals(rootQuestion.getCourseId(), command.courseId())
+                || !Objects.equals(rootQuestion.getLessonId(), command.lessonId())) {
             throw BusinessException.builder(QnaErrorCode.QUESTION_CONTEXT_MISMATCH).build();
         }
 
-        if (parentQuestion.getRootId() != null) {
+        if (!rootQuestion.isRoot()) {
             throw BusinessException.builder(QnaErrorCode.CANNOT_REPLY_TO_REPLY).build();
         }
 
-        validateAnswerPermission(parentQuestion, command.user());
+        validateAnswerPermission(rootQuestion, command.user());
 
         Question reply = Question.createReply(
                 command.rootQuestionId(),
-                parentQuestion.getThreadId(),
+                rootQuestion.getThreadId(),
                 command.courseId(),
                 command.lessonId(),
                 command.user().getId(),
                 command.content()
         );
 
+        boolean isInstructorReply = rootQuestion.isInstructor(command.user().getId());
+        if (isInstructorReply) {
+            rootQuestion.markAsAnswered();
+        } else {
+            rootQuestion.reopen();
+        }
+
+        qnaPersistencePort.save(rootQuestion);
         Question savedReply = qnaPersistencePort.save(reply);
         publishEventPort.publish(QuestionCreatedEvent.from(savedReply));
         return savedReply;
@@ -127,8 +138,7 @@ public class QnaCommandService implements QuestionCommandUseCase {
             return;
         }
 
-        boolean isInstructor = courseClientPort.isInstructor(rootQuestion.getCourseId(), user.getId());
-        if (isInstructor) {
+        if (rootQuestion.isInstructor(user.getId())) {
             return;
         }
 

--- a/src/main/java/com/example/lxp/qna/application/service/QnaQueryService.java
+++ b/src/main/java/com/example/lxp/qna/application/service/QnaQueryService.java
@@ -1,0 +1,26 @@
+package com.example.lxp.qna.application.service;
+
+import com.example.lxp.qna.application.port.in.QuestionQueryUseCase;
+import com.example.lxp.qna.application.port.out.QnaPersistencePort;
+import com.example.lxp.qna.domain.model.Question;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class QnaQueryService implements QuestionQueryUseCase {
+
+    private final QnaPersistencePort qnaPersistencePort;
+
+    public QnaQueryService(QnaPersistencePort qnaPersistencePort) {
+        this.qnaPersistencePort = qnaPersistencePort;
+    }
+
+    @Override
+    public List<Question> findUnansweredQuestionsForInstructor(Long instructorId, int limit) {
+        return qnaPersistencePort.findOpenedRootQuestionsByInstructorId(instructorId, limit);
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/domain/model/Question.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/Question.java
@@ -49,6 +49,12 @@ public class Question {
     @Column(nullable = false)
     private Long authorId;
 
+    @Column(nullable = true)
+    private Long instructorId;
+
+    @Column(nullable = true)
+    private Instant lastActivityAt;
+
     // Content Fields ----------
 
     @Column(nullable = true)
@@ -74,27 +80,34 @@ public class Question {
 
     protected Question() {}
 
-    private Question(Long rootId, String threadId, Long courseId, Long lessonId, Long authorId, String title, String content) {
+    private Question(Long rootId, String threadId, Long courseId, Long lessonId, Long authorId,
+                     Long instructorId, String title, String content) {
         validate(title, content, rootId, threadId);
         this.rootId = rootId;
         this.threadId = threadId;
         this.courseId = courseId;
         this.lessonId = lessonId;
         this.authorId = authorId;
+        this.instructorId = instructorId;
         this.title = title;
         this.content = content;
-        this.status = QuestionStatus.OPENED;
+        if (rootId == null) {
+            this.status = QuestionStatus.OPENED;
+            this.lastActivityAt = Instant.now();
+        }
     }
 
     // Factory Methods ----------
 
-    public static Question createRoot(Long courseId, Long lessonId, Long authorId, String title, String content) {
+    public static Question createRoot(Long courseId, Long lessonId, Long authorId, Long instructorId,
+                                       String title, String content) {
         String threadId = UUID.randomUUID().toString();
-        return new Question(null, threadId, courseId, lessonId, authorId, title, content);
+        return new Question(null, threadId, courseId, lessonId, authorId, instructorId, title, content);
     }
 
-    public static Question createReply(Long rootId, String threadId, Long courseId, Long lessonId, Long authorId, String content) {
-        return new Question(rootId, threadId, courseId, lessonId, authorId, null, content);
+    public static Question createReply(Long rootId, String threadId, Long courseId, Long lessonId,
+                                        Long authorId, String content) {
+        return new Question(rootId, threadId, courseId, lessonId, authorId, null, null, content);
     }
 
     // Business Logics ----------
@@ -112,14 +125,29 @@ public class Question {
         this.status = QuestionStatus.DELETED;
     }
 
-    public void resolve() {
-        if (this.rootId != null) {
-            throw BusinessException.builder(QnaErrorCode.CANNOT_RESOLVE_REPLY).build();
-        }
-        this.status = QuestionStatus.RESOLVED;
+    public void markAsAnswered() {
+        this.status = QuestionStatus.ANSWERED;
+        this.lastActivityAt = Instant.now();
+    }
+
+    public void reopen() {
+        this.status = QuestionStatus.OPENED;
+        this.lastActivityAt = Instant.now();
+    }
+
+    public void updateLastActivity() {
+        this.lastActivityAt = Instant.now();
     }
 
     // Helper Methods ----------
+
+    public boolean isRoot() {
+        return this.rootId == null;
+    }
+
+    public boolean isInstructor(Long userId) {
+        return Objects.equals(this.instructorId, userId);
+    }
 
     public boolean isAuthor(Long userId) {
         return Objects.equals(this.authorId, userId);
@@ -192,6 +220,14 @@ public class Question {
 
     public QuestionStatus getStatus() {
         return status;
+    }
+
+    public Long getInstructorId() {
+        return instructorId;
+    }
+
+    public Instant getLastActivityAt() {
+        return lastActivityAt;
     }
 
 }

--- a/src/main/java/com/example/lxp/qna/domain/model/QuestionStatus.java
+++ b/src/main/java/com/example/lxp/qna/domain/model/QuestionStatus.java
@@ -1,8 +1,7 @@
 package com.example.lxp.qna.domain.model;
 
 public enum QuestionStatus {
-    OPENED,       // Question is active and awaiting answers
-    RESOLVED,   // Question has been satisfactorily answered
-    CLOSED,     // Question thread is closed (e.g., by instructor or admin)
+    OPENED,     // Question is active and awaiting answers
+    ANSWERED,   // Instructor has replied to the question
     DELETED     // Question has been deleted
 }


### PR DESCRIPTION
## ✨ 요약
- External service 장애 상황을 공통 `ExternalServiceErrorCode`로 표준화하고 Feign 호출에서 적절한 BusinessException을 던져 안전한 Fall-back을 준비했습니다.
- QnA 도메인 쪽에서는 RabbitMQ 이벤트 구독/DTO, 내부 컨트롤러, QueryService 등을 추가해 이벤트 기반 삭제 전파와 강사 미답변 QnA 조회를 위한 end point를 구현했습니다.
- `Question` 엔티티에 `instructorId`, `lastActivityAt`을 저장하고 상태/행동(답변/재오픈)을 재구성하며, 퍼시스턴스 계층과 서비스에서 instructor 판단, 답변 시 상태 업데이트, 관련 삭제 메소드를 새로 교체했습니다.

## 📝 작업 내용
- `ExternalServiceErrorCode`를 만들어 타 서비스 실패 상태를 코드로 관리하고 `CourseClientAdapter`가 호출 실패 시 적절한 에러코드를 갖는 `BusinessException`을 던지도록 함.
- `CourseClient`/`CourseClientAdapter`를 `getInstructorId` 형태로 바꾸고 DTO도 `instructorId`만 받아오도록 리팩토링.
- QnA 메시징용 `QnaRabbitEventSubscriber`와 관련 DTO, `QnaInternalController`, `QuestionQueryUseCase`/`QnaQueryService`를 추가해 이벤트 수신과 강사 미답변 QnA 제공하는 API를 구축.
- `Question` 도메인을 `instructorId`, `lastActivityAt` 필드를 포함하도록 확장하고 상태 열거형을 `OPENED/ANSWERED/DELETED`로 바꾸며 관련 비즈니스 메소드(`markAsAnswered`, `reopen`, `isInstructor`, `updateLastActivity`)를 추가.
- Persistence 계층에 lesson/course/author 별 삭제 메소드와 강사 기준 opened questions 조회, 커맨드 서비스에는 instructorId 추가/답변 처리 로직 보강 등을 반영.

## 💭 주의 사항
- RabbitMQ 이벤트 핸들러는 아직 TODO 주석으로만 남아 있어 향후 QnaIntegrationUseCase 주입 및 delete 메소드를 연결해야 함.
- `ExternalServiceErrorCode`를 사용하는 경로에서는 새 코드에 맞춰 Catch/Throw 흐름 검증 및 롤백 정책을 살펴봐 주세요.

## 💡 리뷰 포인트
- `CourseClientAdapter#getInstructorId`가 Feign 예외를 올바른 BusinessException으로 변환하고 있는지?
- `Question` 상태 변경/강사 판별 로직이 답변 및 수정 흐름에서 기대하는 대로 작동하는지?

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
- 없음 (도메인/이벤트 중심 변경)
