### PR TITLE
feat: add review list query endpoint and test code

### DIFF
--- a/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/ReviewController.java
@@ -2,8 +2,10 @@ package com.example.lxp.review.adapter.in.web;
 
 import com.example.lxp.common.auth.model.User;
 import com.example.lxp.review.adapter.in.web.dto.CreateReviewRequest;
+import com.example.lxp.review.adapter.in.web.dto.ReviewListResponse;
 import com.example.lxp.review.adapter.in.web.dto.UpdateReviewRequest;
 import com.example.lxp.review.application.port.in.ReviewCommandUseCase;
+import com.example.lxp.review.application.port.in.ReviewQueryUseCase;
 import com.example.lxp.review.application.port.in.dto.CreateReviewCommand;
 import com.example.lxp.review.application.port.in.dto.DeleteReviewCommand;
 import com.example.lxp.review.application.port.in.dto.UpdateReviewCommand;
@@ -15,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -32,9 +35,21 @@ public class ReviewController {
     private static final String HEADER_USER_ROLE = "X-User-Role";
 
     private final ReviewCommandUseCase reviewCommandUseCase;
+    private final ReviewQueryUseCase reviewQueryUseCase;
 
-    public ReviewController(ReviewCommandUseCase reviewCommandUseCase) {
+    public ReviewController(
+            ReviewCommandUseCase reviewCommandUseCase,
+            ReviewQueryUseCase reviewQueryUseCase
+    ) {
         this.reviewCommandUseCase = reviewCommandUseCase;
+        this.reviewQueryUseCase = reviewQueryUseCase;
+    }
+
+    @GetMapping
+    public ResponseEntity<ReviewListResponse> getReviews(
+            @PathVariable @Positive Long courseId
+    ) {
+        return ResponseEntity.ok(reviewQueryUseCase.getReviewsByCourseId(courseId));
     }
 
     @PostMapping

--- a/src/main/java/com/example/lxp/review/adapter/in/web/dto/ReviewItemResponse.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/dto/ReviewItemResponse.java
@@ -1,0 +1,35 @@
+package com.example.lxp.review.adapter.in.web.dto;
+
+import com.example.lxp.review.domain.model.Review;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewItemResponse {
+
+    private final Long reviewId;
+    private final Long courseId;
+    private final Long userId;
+    private final String userNickname;
+    private final String title;
+    private final String comment;
+    private final Integer rating;
+    private final Instant updatedAt;
+
+    public static ReviewItemResponse from(Review review, String userNickname) {
+        return new ReviewItemResponse(
+                review.getId(),
+                review.getCourseId(),
+                review.getAuthorId(),
+                userNickname,
+                review.getTitle(),
+                review.getComment(),
+                review.getRating().getStars(),
+                review.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/lxp/review/adapter/in/web/dto/ReviewListResponse.java
+++ b/src/main/java/com/example/lxp/review/adapter/in/web/dto/ReviewListResponse.java
@@ -1,0 +1,18 @@
+package com.example.lxp.review.adapter.in.web.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewListResponse {
+
+    private final List<ReviewItemResponse> reviews;
+
+    public static ReviewListResponse of(List<ReviewItemResponse> reviews) {
+        return new ReviewListResponse(reviews);
+    }
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClient.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClient.java
@@ -1,0 +1,16 @@
+package com.example.lxp.review.adapter.out.external;
+
+import com.example.lxp.review.adapter.out.external.dto.UserNicknameResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "user-nickname-api",
+        url = "${user-api.url:http://localhost:8080}"
+)
+public interface ReviewUserClient {
+
+    @GetMapping("/server/users/nickname")
+    UserNicknameResponse getNickname(@RequestParam Long userId);
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClientAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClientAdapter.java
@@ -1,0 +1,50 @@
+package com.example.lxp.review.adapter.out.external;
+
+import com.example.lxp.review.adapter.out.external.dto.UserNicknameResponse;
+import com.example.lxp.review.application.port.out.UserClientPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class ReviewUserClientAdapter implements UserClientPort {
+
+    private static final String UNKNOWN_NICKNAME = "알 수 없음";
+
+    private final ReviewUserClient reviewUserClient;
+
+    public ReviewUserClientAdapter(ReviewUserClient reviewUserClient) {
+        this.reviewUserClient = reviewUserClient;
+    }
+
+    @Override
+    public Map<Long, String> getNicknames(Set<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return userIds.stream()
+                .collect(Collectors.toMap(
+                        userId -> userId,
+                        this::fetchNicknameSafely
+                ));
+    }
+
+    private String fetchNicknameSafely(Long userId) {
+        try {
+            UserNicknameResponse response = reviewUserClient.getNickname(userId);
+            if (response == null || response.nickname() == null) {
+                return UNKNOWN_NICKNAME;
+            }
+            return response.nickname();
+        } catch (Exception ex) {
+            log.warn("Failed to fetch nickname for userId={}, falling back to unknown", userId, ex);
+            return UNKNOWN_NICKNAME;
+        }
+    }
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/external/dto/UserNicknameResponse.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/dto/UserNicknameResponse.java
@@ -1,0 +1,7 @@
+package com.example.lxp.review.adapter.out.external.dto;
+
+public record UserNicknameResponse(
+        Long userId,
+        String nickname
+) {
+}

--- a/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.example.lxp.review.adapter.out.persistence;
 
 import com.example.lxp.review.application.port.out.ReviewPersistencePort;
 import com.example.lxp.review.domain.model.Review;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -34,6 +35,11 @@ public class ReviewPersistenceAdapter implements ReviewPersistencePort {
     @Override
     public List<Review> findAllByCourseId(Long courseId) {
         return reviewRepository.findByCourseId(courseId);
+    }
+
+    @Override
+    public List<Review> findAllByCourseId(Long courseId, Sort sort) {
+        return reviewRepository.findByCourseId(courseId, sort);
     }
 
     @Override

--- a/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewRepository.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/persistence/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.example.lxp.review.adapter.out.persistence;
 
 import com.example.lxp.review.domain.model.Review;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByCourseId(Long courseId);
+
+    List<Review> findByCourseId(Long courseId, Sort sort);
 
     long countByCourseId(Long courseId);
 

--- a/src/main/java/com/example/lxp/review/application/port/in/ReviewQueryUseCase.java
+++ b/src/main/java/com/example/lxp/review/application/port/in/ReviewQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.example.lxp.review.application.port.in;
+
+import com.example.lxp.review.adapter.in.web.dto.ReviewListResponse;
+
+public interface ReviewQueryUseCase {
+
+    ReviewListResponse getReviewsByCourseId(Long courseId);
+}

--- a/src/main/java/com/example/lxp/review/application/port/out/ReviewPersistencePort.java
+++ b/src/main/java/com/example/lxp/review/application/port/out/ReviewPersistencePort.java
@@ -1,6 +1,7 @@
 package com.example.lxp.review.application.port.out;
 
 import com.example.lxp.review.domain.model.Review;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,8 @@ public interface ReviewPersistencePort {
     void delete(Review review);
 
     List<Review> findAllByCourseId(Long courseId);
+
+    List<Review> findAllByCourseId(Long courseId, Sort sort);
 
     long countByCourseId(Long courseId);
 

--- a/src/main/java/com/example/lxp/review/application/port/out/UserClientPort.java
+++ b/src/main/java/com/example/lxp/review/application/port/out/UserClientPort.java
@@ -1,0 +1,10 @@
+package com.example.lxp.review.application.port.out;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface UserClientPort {
+
+    Map<Long, String> getNicknames(Set<Long> userIds);
+    
+}

--- a/src/main/java/com/example/lxp/review/application/service/ReviewQueryService.java
+++ b/src/main/java/com/example/lxp/review/application/service/ReviewQueryService.java
@@ -1,7 +1,61 @@
 package com.example.lxp.review.application.service;
 
-public class ReviewQueryService {
+import com.example.lxp.review.adapter.in.web.dto.ReviewItemResponse;
+import com.example.lxp.review.adapter.in.web.dto.ReviewListResponse;
+import com.example.lxp.review.application.port.in.ReviewQueryUseCase;
+import com.example.lxp.review.application.port.out.ReviewPersistencePort;
+import com.example.lxp.review.application.port.out.UserClientPort;
+import com.example.lxp.review.domain.model.Review;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-    // TODO
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+@Service
+@Transactional(readOnly = true)
+public class ReviewQueryService implements ReviewQueryUseCase {
+
+    private static final Sort DEFAULT_SORT = Sort.by("updatedAt").descending()
+            .and(Sort.by("id").descending());
+    private static final String UNKNOWN_NICKNAME = "알 수 없음";
+
+    private final ReviewPersistencePort reviewPersistencePort;
+    private final UserClientPort userClientPort;
+
+    public ReviewQueryService(
+            ReviewPersistencePort reviewPersistencePort,
+            UserClientPort userClientPort
+    ) {
+        this.reviewPersistencePort = reviewPersistencePort;
+        this.userClientPort = userClientPort;
+    }
+
+    @Override
+    public ReviewListResponse getReviewsByCourseId(Long courseId) {
+        List<Review> reviews = reviewPersistencePort.findAllByCourseId(courseId, DEFAULT_SORT);
+
+        if (reviews.isEmpty()) {
+            return ReviewListResponse.of(Collections.emptyList());
+        }
+
+        Set<Long> authorIds = reviews.stream()
+                .map(Review::getAuthorId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> nicknameMap = userClientPort.getNicknames(authorIds);
+
+        List<ReviewItemResponse> reviewItems = reviews.stream()
+                .map(review -> ReviewItemResponse.from(
+                        review,
+                        nicknameMap.getOrDefault(review.getAuthorId(), UNKNOWN_NICKNAME)
+                ))
+                .toList();
+
+        return ReviewListResponse.of(reviewItems);
+    }
 }

--- a/src/main/java/com/example/lxp/review/domain/model/Rating.java
+++ b/src/main/java/com/example/lxp/review/domain/model/Rating.java
@@ -21,7 +21,10 @@ public class Rating {
     }
 
     public static Rating of(Integer stars) {
-        if (stars == null || (stars < RATING_MIN || stars > RATING_MAX)) {
+        if (stars == null) {
+            throw BusinessException.builder(ReviewErrorCode.REVIEW_RATING_IS_BLANK).build();
+        }
+        if (stars < RATING_MIN || stars > RATING_MAX) {
             throw BusinessException.builder(ReviewErrorCode.RATING_OUT_OF_RANGE).build();
         }
         return new Rating(stars);

--- a/src/test/java/com/example/lxp/review/domain/model/RatingTest.java
+++ b/src/test/java/com/example/lxp/review/domain/model/RatingTest.java
@@ -1,0 +1,48 @@
+package com.example.lxp.review.domain.model;
+
+import com.example.lxp.exception.BusinessException;
+import com.example.lxp.review.exception.ReviewErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RatingTest {
+
+    @Nested
+    @DisplayName("of")
+    class Of {
+
+        @Test
+        @DisplayName("별점이 0~5 사이면 생성된다")
+        void shouldCreateWhenStarsWithinRange() {
+            assertThat(Rating.of(0).getStars()).isEqualTo(0);
+            assertThat(Rating.of(5).getStars()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("별점이 null이면 REV-0005를 던진다")
+        void shouldThrowWhenStarsIsNull() {
+            assertThatThrownBy(() -> Rating.of(null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_RATING_IS_BLANK));
+        }
+
+        @Test
+        @DisplayName("범위를 벗어나면 REV-0001을 던진다")
+        void shouldThrowWhenStarsOutOfRange() {
+            assertThatThrownBy(() -> Rating.of(-1))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.RATING_OUT_OF_RANGE));
+
+            assertThatThrownBy(() -> Rating.of(6))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.RATING_OUT_OF_RANGE));
+        }
+    }
+}

--- a/src/test/java/com/example/lxp/review/domain/model/ReviewTest.java
+++ b/src/test/java/com/example/lxp/review/domain/model/ReviewTest.java
@@ -1,0 +1,126 @@
+package com.example.lxp.review.domain.model;
+
+import com.example.lxp.common.auth.model.User;
+import com.example.lxp.exception.BusinessException;
+import com.example.lxp.review.exception.ReviewErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReviewTest {
+
+    private static final long AUTHOR_ID = 10L;
+    private static final long OTHER_ID = 99L;
+    private static final long COURSE_ID = 1L;
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("필수 값이 모두 있으면 생성된다")
+        void shouldCreateWhenFieldsAreValid() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "title", "comment", Rating.of(5));
+            assertThat(review.getAuthorId()).isEqualTo(AUTHOR_ID);
+            assertThat(review.getCourseId()).isEqualTo(COURSE_ID);
+            assertThat(review.getTitle()).isEqualTo("title");
+            assertThat(review.getComment()).isEqualTo("comment");
+            assertThat(review.getRating().getStars()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("제목이 null/blank이면 REV-0003")
+        void shouldThrowWhenTitleInvalid() {
+            assertThatThrownBy(() -> Review.create(AUTHOR_ID, COURSE_ID, null, "c", Rating.of(5)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_TITLE_IS_BLANK));
+
+            assertThatThrownBy(() -> Review.create(AUTHOR_ID, COURSE_ID, "  ", "c", Rating.of(5)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_TITLE_IS_BLANK));
+        }
+
+        @Test
+        @DisplayName("내용이 null/blank이면 REV-0004")
+        void shouldThrowWhenCommentInvalid() {
+            assertThatThrownBy(() -> Review.create(AUTHOR_ID, COURSE_ID, "t", null, Rating.of(5)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_COMMENT_IS_BLANK));
+
+            assertThatThrownBy(() -> Review.create(AUTHOR_ID, COURSE_ID, "t", "   ", Rating.of(5)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_COMMENT_IS_BLANK));
+        }
+
+        @Test
+        @DisplayName("평점이 null이면 REV-0005")
+        void shouldThrowWhenRatingIsNull() {
+            assertThatThrownBy(() -> Review.create(AUTHOR_ID, COURSE_ID, "t", "c", null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_RATING_IS_BLANK));
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("작성자가 아니면 REV-0007")
+        void shouldThrowWhenNotAuthor() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "t", "c", Rating.of(5));
+            assertThatThrownBy(() -> review.update(OTHER_ID, "nt", "nc", Rating.of(4)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.FORBIDDEN_REVIEW_MODIFICATION));
+        }
+
+        @Test
+        @DisplayName("제목을 공백으로 수정하면 REV-0003")
+        void shouldThrowWhenTitleBlankOnUpdate() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "t", "c", Rating.of(5));
+            assertThatThrownBy(() -> review.update(AUTHOR_ID, "  ", null, null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_TITLE_IS_BLANK));
+        }
+
+        @Test
+        @DisplayName("내용을 공백으로 수정하면 REV-0004")
+        void shouldThrowWhenCommentBlankOnUpdate() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "t", "c", Rating.of(5));
+            assertThatThrownBy(() -> review.update(AUTHOR_ID, null, "  ", null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(ex -> assertThat(((BusinessException) ex).getCode())
+                            .isEqualTo(ReviewErrorCode.REVIEW_COMMENT_IS_BLANK));
+        }
+
+        @Test
+        @DisplayName("부분 업데이트: null은 기존 값을 유지한다")
+        void shouldKeepOriginalWhenFieldIsNull() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "t", "c", Rating.of(5));
+            review.update(AUTHOR_ID, null, null, null);
+            assertThat(review.getTitle()).isEqualTo("t");
+            assertThat(review.getComment()).isEqualTo("c");
+            assertThat(review.getRating().getStars()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("제목/내용/평점이 올바르면 수정된다")
+        void shouldUpdateWhenFieldsValid() {
+            Review review = Review.create(AUTHOR_ID, COURSE_ID, "t", "c", Rating.of(5));
+            review.update(AUTHOR_ID, "nt", "nc", Rating.of(3));
+            assertThat(review.getTitle()).isEqualTo("nt");
+            assertThat(review.getComment()).isEqualTo("nc");
+            assertThat(review.getRating().getStars()).isEqualTo(3);
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
- 코스별 리뷰 목록 조회 API를 추가하고, 작성자 닉네임을 외부 User API에서 조회하여 응답에 포함합니다.
- 리뷰 목록 정렬을 `updatedAt desc, id desc`로 고정하여 안정적인 정렬을 보장합니다.

## 📝 작업 내용
- Review 조회 유스케이스/서비스 추가
  - `ReviewQueryUseCase`, `ReviewQueryService` 구현
  - 기본 정렬: `updatedAt DESC` → `id DESC`
- 리뷰 목록 조회 엔드포인트 노출
  - `GET /api/courses/{courseId}/reviews`
  - 응답 DTO: `ReviewListResponse`, `ReviewItemResponse`
- 작성자 닉네임 조회를 위한 UserClient Port/Adapter 추가
  - Feign Client 기반 `ReviewUserClient` 및 `ReviewUserClientAdapter`
  - 닉네임 조회 실패/응답 누락 시 `"알 수 없음"`으로 fallback
- Persistence 확장
  - `findByCourseId(courseId, Sort sort)` 지원하도록 Port/Repository/Adapter 확장
- 도메인 규칙 보강 및 테스트 추가
  - `Rating.of(null)`일 때 범위 오류가 아닌 “필수값 누락” 에러코드로 처리하도록 수정
  - `Review`, `Rating` 도메인 테스트 추가

## 💭 주의 사항
- 닉네임 조회는 현재 작성자 ID 수만큼 외부 호출이 발생할 수 있습니다(N명 = N회).
  - 트래픽/지연이 우려되면 batch API 또는 캐싱 전략이 필요할 수 있습니다.
- User API 주소는 `${user-api.url:http://localhost:8080}` 기본값을 사용합니다.
  - 배포/로컬 환경에서 설정 누락 시 기대하지 않은 대상(localhost)으로 호출될 수 있어 확인이 필요합니다.
- 닉네임 조회 실패 시 응답 닉네임은 `"알 수 없음"`으로 내려갑니다.

## 💡 리뷰 포인트
- 리뷰 정렬 기준이 요구사항에 맞는지(`updatedAt desc`, `id desc`) 확인 부탁드립니다.
- 닉네임 조회 방식(개별 호출/fallback 문자열)이 서비스 정책상 적절한지 확인 부탁드립니다.
- 리뷰 목록 응답 DTO 필드 구성이 프론트 요구사항에 충분한지 확인 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
 리뷰 목록 조회
- Request: `GET /api/courses/{courseId}/reviews`
- Response 예시
```
{
  "reviews": [
    {
      "reviewId": 1,
      "courseId": 10,
      "userId": 100,
      "userNickname": "닉네임",
      "title": "title",
      "comment": "comment",
      "rating": 5,
      "updatedAt": "2026-01-14T00:00:00Z"
    }
  ]
}
```