### PR TITLE
feat: add circuit breaker on external API call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.8'
+    id 'org.springframework.boot' version '3.5.9'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/com/example/lxp/common/external/user/adapter/UserNicknameGateway.java
+++ b/src/main/java/com/example/lxp/common/external/user/adapter/UserNicknameGateway.java
@@ -1,0 +1,192 @@
+package com.example.lxp.common.external.user.adapter;
+
+import com.example.lxp.common.external.user.UserApiClient;
+import com.example.lxp.common.external.user.dto.UserNicknameResponse;
+import com.example.lxp.common.external.user.dto.UserNicknamesResponse;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+@Component
+public class UserNicknameGateway {
+
+    private static final String UNKNOWN_NICKNAME = "알 수 없음";
+
+    private static final String METHOD_SINGLE = "single";
+    private static final String METHOD_BATCH = "batch";
+
+    private static final String CB_SINGLE = "user-api-nickname";
+    private static final String CB_BATCH = "user-api-nicknames";
+
+    private static final String METRIC_PREFIX = "interaction_user_nickname_";
+    private static final String INTERACTION_USER_NICKNAME_REQUESTED_IDS_TOTAL = METRIC_PREFIX + "requested_ids_total";
+    private static final String INTERACTION_USER_NICKNAME_UNKNOWN_RETURNED_IDS_TOTAL = METRIC_PREFIX + "unknown_returned_ids_total";
+    private static final String INTERACTION_USER_NICKNAME_NOT_FOUND_TOTAL = METRIC_PREFIX + "not_found_total";
+    private static final String INTERACTION_USER_NICKNAME_BATCH_MISSING_IDS_TOTAL = METRIC_PREFIX + "batch_missing_ids_total";
+    private static final String INTERACTION_USER_NICKNAME_FALLBACK_TOTAL = METRIC_PREFIX + "fallback_total";
+
+    private static final String TAG_METHOD = "method";
+    private static final String TAG_REASON = "reason";
+
+    private static final String REASON_CB_OPEN = "cb_open";
+    private static final String REASON_TIMEOUT = "timeout";
+    private static final String REASON_IO = "io";
+    private static final String REASON_4XX = "4xx";
+    private static final String REASON_5XX = "5xx";
+    private static final String REASON_FEIGN = "feign";
+    private static final String REASON_OTHER = "other";
+
+    private final UserApiClient userApiClient;
+    private final CircuitBreakerFactory<?, ?> circuitBreakerFactory;
+    private final MeterRegistry meterRegistry;
+
+    public UserNicknameGateway(
+            UserApiClient userApiClient,
+            CircuitBreakerFactory<?, ?> circuitBreakerFactory,
+            MeterRegistry meterRegistry
+    ) {
+        this.userApiClient = userApiClient;
+        this.circuitBreakerFactory = circuitBreakerFactory;
+        this.meterRegistry = meterRegistry;
+    }
+
+    public String getNickname(Long userId) {
+        if (userId == null) {
+            return UNKNOWN_NICKNAME;
+        }
+
+        recordRequestedIds(1, METHOD_SINGLE);
+
+        CircuitBreaker circuitBreaker = circuitBreakerFactory.create(CB_SINGLE);
+        return circuitBreaker.run(
+                () -> {
+                    try {
+                        UserNicknameResponse response = userApiClient.getNickname(userId);
+                        String nickname = response != null ? response.nickname() : null;
+                        if (nickname == null) {
+                            recordUnknownReturned(1, METHOD_SINGLE);
+                            return UNKNOWN_NICKNAME;
+                        }
+                        return nickname;
+                    } catch (FeignException.NotFound notFound) {
+                        recordNotFound();
+                        recordUnknownReturned(1, METHOD_SINGLE);
+                        return UNKNOWN_NICKNAME;
+                    }
+                },
+                throwable -> {
+                    recordFallback(METHOD_SINGLE, classifyReason(throwable));
+                    recordUnknownReturned(1, METHOD_SINGLE);
+                    return UNKNOWN_NICKNAME;
+                }
+        );
+    }
+
+    public Map<Long, String> getNicknames(Set<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        int requestedCount = userIds.size();
+        recordRequestedIds(requestedCount, METHOD_BATCH);
+
+        CircuitBreaker circuitBreaker = circuitBreakerFactory.create(CB_BATCH);
+        return circuitBreaker.run(
+                () -> {
+                    UserNicknamesResponse response = userApiClient.getNicknames(List.copyOf(userIds));
+
+                    Map<Long, String> result = new HashMap<>();
+                    if (response != null && response.nicknames() != null) {
+                        result.putAll(response.nicknames());
+                    }
+
+                    Set<Long> missing = new HashSet<>(userIds);
+                    missing.removeAll(result.keySet());
+                    if (response != null && response.missingUserIds() != null) {
+                        missing.addAll(response.missingUserIds());
+                    }
+
+                    if (!missing.isEmpty()) {
+                        int missingCount = missing.size();
+                        recordBatchMissingIds(missingCount);
+                        recordUnknownReturned(missingCount, METHOD_BATCH);
+                        for (Long userId : missing) {
+                            result.put(userId, UNKNOWN_NICKNAME);
+                        }
+                    }
+
+                    return result;
+                },
+                throwable -> {
+                    recordFallback(METHOD_BATCH, classifyReason(throwable));
+                    recordUnknownReturned(requestedCount, METHOD_BATCH);
+                    return createUnknownMap(userIds);
+                }
+        );
+    }
+
+    private Map<Long, String> createUnknownMap(Set<Long> userIds) {
+        Map<Long, String> result = new HashMap<>();
+        for (Long userId : userIds) {
+            result.put(userId, UNKNOWN_NICKNAME);
+        }
+        return result;
+    }
+
+    private void recordRequestedIds(int count, String method) {
+        meterRegistry.counter(INTERACTION_USER_NICKNAME_REQUESTED_IDS_TOTAL, TAG_METHOD, method).increment(count);
+    }
+
+    private void recordUnknownReturned(int count, String method) {
+        meterRegistry.counter(INTERACTION_USER_NICKNAME_UNKNOWN_RETURNED_IDS_TOTAL, TAG_METHOD, method).increment(count);
+    }
+
+    private void recordNotFound() {
+        meterRegistry.counter(INTERACTION_USER_NICKNAME_NOT_FOUND_TOTAL).increment();
+    }
+
+    private void recordBatchMissingIds(int missingCount) {
+        meterRegistry.counter(INTERACTION_USER_NICKNAME_BATCH_MISSING_IDS_TOTAL).increment(missingCount);
+    }
+
+    private void recordFallback(String method, String reason) {
+        meterRegistry.counter(INTERACTION_USER_NICKNAME_FALLBACK_TOTAL, TAG_METHOD, method, TAG_REASON, reason).increment();
+    }
+
+    private String classifyReason(Throwable throwable) {
+        if (throwable instanceof CallNotPermittedException) {
+            return REASON_CB_OPEN;
+        }
+        if (throwable instanceof TimeoutException) {
+            return REASON_TIMEOUT;
+        }
+        if (throwable instanceof IOException) {
+            return REASON_IO;
+        }
+        if (throwable instanceof FeignException.FeignClientException) {
+            return REASON_4XX;
+        }
+        if (throwable instanceof FeignException.FeignServerException) {
+            return REASON_5XX;
+        }
+        if (throwable instanceof FeignException) {
+            return REASON_FEIGN;
+        }
+        return REASON_OTHER;
+    }
+
+}

--- a/src/main/java/com/example/lxp/qna/adapter/out/external/QnaUserClientAdapter.java
+++ b/src/main/java/com/example/lxp/qna/adapter/out/external/QnaUserClientAdapter.java
@@ -1,69 +1,23 @@
 package com.example.lxp.qna.adapter.out.external;
 
-import com.example.lxp.common.external.user.UserApiClient;
-import com.example.lxp.common.external.user.dto.UserNicknamesResponse;
+import com.example.lxp.common.external.user.adapter.UserNicknameGateway;
 import com.example.lxp.qna.application.port.out.QnaUserClientPort;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Slf4j
 @Component
 public class QnaUserClientAdapter implements QnaUserClientPort {
 
-    private static final String UNKNOWN_NICKNAME = "알 수 없음";
+    private final UserNicknameGateway userNicknameGateway;
 
-    private final UserApiClient userApiClient;
-
-    public QnaUserClientAdapter(UserApiClient userApiClient) {
-        this.userApiClient = userApiClient;
+    public QnaUserClientAdapter(UserNicknameGateway userNicknameGateway) {
+        this.userNicknameGateway = userNicknameGateway;
     }
 
     @Override
     public Map<Long, String> getNicknames(Set<Long> userIds) {
-        if (userIds == null || userIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        try {
-            UserNicknamesResponse response = userApiClient.getNicknames(List.copyOf(userIds));
-            return mergeWithUnknowns(userIds, response);
-        } catch (Exception ex) {
-            log.warn("Failed to fetch nicknames for userIds={}, falling back to unknown", userIds, ex);
-            return createUnknownMap(userIds);
-        }
-    }
-
-    private Map<Long, String> mergeWithUnknowns(Set<Long> userIds, UserNicknamesResponse response) {
-        Map<Long, String> result = new HashMap<>();
-        if (response != null && response.nicknames() != null) {
-            result.putAll(response.nicknames());
-        }
-
-        Set<Long> missing = new HashSet<>(userIds);
-        missing.removeAll(result.keySet());
-        if (response != null && response.missingUserIds() != null) {
-            missing.addAll(response.missingUserIds());
-        }
-
-        for (Long userId : missing) {
-            result.put(userId, UNKNOWN_NICKNAME);
-        }
-
-        return result;
-    }
-
-    private Map<Long, String> createUnknownMap(Set<Long> userIds) {
-        Map<Long, String> result = new HashMap<>();
-        for (Long userId : userIds) {
-            result.put(userId, UNKNOWN_NICKNAME);
-        }
-        return result;
+        return userNicknameGateway.getNicknames(userIds);
     }
 }

--- a/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClientAdapter.java
+++ b/src/main/java/com/example/lxp/review/adapter/out/external/ReviewUserClientAdapter.java
@@ -1,69 +1,23 @@
 package com.example.lxp.review.adapter.out.external;
 
-import com.example.lxp.common.external.user.UserApiClient;
-import com.example.lxp.common.external.user.dto.UserNicknamesResponse;
+import com.example.lxp.common.external.user.adapter.UserNicknameGateway;
 import com.example.lxp.review.application.port.out.ReviewUserClientPort;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@Slf4j
 @Component
 public class ReviewUserClientAdapter implements ReviewUserClientPort {
 
-    private static final String UNKNOWN_NICKNAME = "알 수 없음";
+    private final UserNicknameGateway userNicknameGateway;
 
-    private final UserApiClient userApiClient;
-
-    public ReviewUserClientAdapter(UserApiClient userApiClient) {
-        this.userApiClient = userApiClient;
+    public ReviewUserClientAdapter(UserNicknameGateway userNicknameGateway) {
+        this.userNicknameGateway = userNicknameGateway;
     }
 
     @Override
     public Map<Long, String> getNicknames(Set<Long> userIds) {
-        if (userIds == null || userIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        try {
-            UserNicknamesResponse response = userApiClient.getNicknames(List.copyOf(userIds));
-            return mergeWithUnknowns(userIds, response);
-        } catch (Exception ex) {
-            log.warn("Failed to fetch nicknames for userIds={}, falling back to unknown", userIds, ex);
-            return createUnknownMap(userIds);
-        }
-    }
-
-    private Map<Long, String> mergeWithUnknowns(Set<Long> userIds, UserNicknamesResponse response) {
-        Map<Long, String> result = new HashMap<>();
-        if (response != null && response.nicknames() != null) {
-            result.putAll(response.nicknames());
-        }
-
-        Set<Long> missing = new HashSet<>(userIds);
-        missing.removeAll(result.keySet());
-        if (response != null && response.missingUserIds() != null) {
-            missing.addAll(response.missingUserIds());
-        }
-
-        for (Long userId : missing) {
-            result.put(userId, UNKNOWN_NICKNAME);
-        }
-
-        return result;
-    }
-
-    private Map<Long, String> createUnknownMap(Set<Long> userIds) {
-        Map<Long, String> result = new HashMap<>();
-        for (Long userId : userIds) {
-            result.put(userId, UNKNOWN_NICKNAME);
-        }
-        return result;
+        return userNicknameGateway.getNicknames(userIds);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
* 유저 닉네임 API 요청에 서킷브레이커 적용
* 유저 닉네임 API 요청에 대한 결과값 메트릭 추적

## 📝 작업 내용
* feign client에 서킷브레이커 구현
* 전체 요청 횟수 메트릭 수집 - 분모
* 매핑 실패로 "알 수 없음" 매핑된 횟수 - 분자
* 단건 조회에서 404 발생 비율 - 데이터 품질 지표
* 다건 조회에서 missing 처리된 ID 수 - 데이터 품질 지표
* 완전 실패로 fallback 처리된 호출 회수 - reason 추적, 실제 서비스 지표

## 💭 주의 사항

## 💡 리뷰 포인트
* unknown이 많다
  * 원인이 데이터 부재인지 장애인지 분리:
  * not_found_total / batch_missing_ids_total 이 같이 높으면 -> 데이터 정합성 문제
  * fallback_total 이 높으면 장애/연결문제/서킷오픈 쪽 문제 -> 외부 서비스가 문제
* unknown 비율
  * unknown_returned_ids_total / requested_ids_total
* 배치에서 데이터 누락 비율
  * batch_missing_ids_total / requested_ids_total{method="batch"}
* 장애로 인한 degrade 빈도
  * increase(fallback_total[5m]) + reason별 breakdown

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
